### PR TITLE
add Siege Barracks to HOME_TROOP_ORDER

### DIFF
--- a/coc/enums.py
+++ b/coc/enums.py
@@ -75,6 +75,7 @@ HOME_TROOP_ORDER = [
     "Wall Wrecker",
     "Battle Blimp",
     "Stone Slammer",
+    "Siege Barracks",
 ]
 
 BUILDER_TROOPS_ORDER = [


### PR DESCRIPTION
I forgot the Siege Barracks in the HOME_TROOP_ORDER