### PR TITLE
Added army link and create command and modified regex and code of army link

### DIFF
--- a/coc/client.py
+++ b/coc/client.py
@@ -1645,9 +1645,10 @@ class Client:
                     raise ValueError("I couldn't find the troop or spell called '{}'.".format(key))
 
         if troops:
-            base += "u" + "-".join("{id}x{qty}".format(id=troop.id - 4_000_000, qty=qty) for troop, qty in troops)
+            base += "u" + "-".join("{qty}x{id}".format(qty=qty, id=troop.id - 4_000_000) for troop, qty in troops)
+            
         if spells:
-            base += "s" + "-".join("{id}x{qty}".format(id=spell.id - 26_000_000, qty=qty) for spell, qty in spells)
+            base += "s" + "-".join("{qty}x{id}".format(qty=qty, id=spell.id - 26_000_000) for spell, qty in spells)
 
         return base
 

--- a/coc/utils.py
+++ b/coc/utils.py
@@ -34,7 +34,7 @@ from typing import Any, Callable, Generic, Iterable, List, Optional, Type, TypeV
 
 
 TAG_VALIDATOR = re.compile(r"^#?[PYLQGRJCUV0289]+$")
-ARMY_LINK_SEPERATOR = re.compile(r"u([\d+x-]+)s([\d+x-]+)")
+ARMY_LINK_SEPERATOR = re.compile(r"u([\d+x-]+)|s([\d+x-]+)")
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
@@ -208,13 +208,24 @@ def parse_army_link(link: str) -> Tuple[List[Tuple[int, int]], List[Tuple[int, i
     if not match:
         return [], []
 
-    return [
-        (4_000_000 + int(split[1]), int(split[0]))
-        for split in (troop.split('x') for troop in match[0][0].split('-'))
-    ], [
-        (26_000_000 + int(split[1]), int(split[0]))
-        for split in (spell.split('x') for spell in match[0][1].split('-'))
-    ]
+    _troop,_spell = [], [] #return empty list in case either troop or spell is not present in link
+    try:
+        for _match in match:
+            if _match[0]:
+                _troop = [
+                (4_000_000 + int(split[1]), int(split[0]))
+                for split in (troop.split('x') for troop in _match[0].split('-'))
+            ]
+
+            if _match[1]:
+                _spell = [
+                (26_000_000 + int(split[1]), int(split[0]))
+                for split in (spell.split('x') for spell in _match[1].split('-'))
+            ]
+
+    except IndexError: #passing index error
+        pass
+    return _troop, _spell 
 
 
 def maybe_sort(

--- a/examples/discord_bot.py
+++ b/examples/discord_bot.py
@@ -13,7 +13,6 @@ import discord
 from coc import utils
 from discord.ext import commands
 
-
 INFO_CHANNEL_ID = 761848043242127370  # some discord channel ID
 clan_tags = ["#20090C9PR", "#202GG92Q", "#20C8G0RPL"]
 
@@ -27,11 +26,17 @@ coc_client = coc.login(
 logging.basicConfig(level=logging.ERROR)
 
 
+@bot.event
+async def on_ready():
+    print("Logged in!!")
+
+
 @coc_client.event
 @coc.ClanEvents.member_join(tags=clan_tags)
 async def on_clan_member_join(member, clan):
     await bot.get_channel(INFO_CHANNEL_ID).send(
-        "{0.name} ({0.tag}) just " "joined our clan {1.name} ({1.tag})!".format(member, clan)
+        "{0.name} ({0.tag}) just " "joined our clan {1.name} ({1.tag})!".format(
+            member, clan)
     )
 
 
@@ -39,7 +44,8 @@ async def on_clan_member_join(member, clan):
 @coc.ClanEvents.member_name(tags=clan_tags)
 async def member_name_change(old_player, new_player):
     await bot.get_channel(INFO_CHANNEL_ID).send(
-        "Name Change! {0.name} is now called {1.name} (his tag is {1.tag})".format(old_player, new_player)
+        "Name Change! {0.name} is now called {1.name} (his tag is {1.tag})".format(
+            old_player, new_player)
     )
 
 
@@ -63,13 +69,44 @@ async def player_heroes(ctx, player_tag):
     except coc.NotFound:
         await ctx.send("This player doesn't exist!")
         return
-        
+
     to_send = ""
     for hero in player.heroes:
-        to_send += "{}: Lv{}/{}\n".format(str(hero), hero.level, hero.max_level)
+        to_send += "{}: Lv{}/{}\n".format(str(hero),
+                                          hero.level, hero.max_level)
 
     await ctx.send(to_send)
 
+
+@bot.command()
+async def parse_army(ctx, army_link: str):
+    troops, spells = coc_client.parse_army_link(army_link)
+    print(troops, spells)
+    parsed_link_output = ''
+    if troops or spells:  # checking if troops or spells is present in link
+
+        for troop, quantity in troops:
+            parsed_link_output += "The user wants {} {}s. They each have {} DPS.\n".format(
+                quantity, troop.name, troop.dps)
+
+        for spell, quantity in spells:
+            parsed_link_output += "The user wants {} {}s.\n".format(
+                quantity, spell.name)
+    else:
+        parsed_link_output += "Invalid Link!"
+    await ctx.send(parsed_link_output)
+
+@bot.command()
+async def create_army(ctx):
+    link = coc_client.create_army_link(
+        barbarian=10,
+        archer=20,
+        hog_rider=30,
+        healing_spell=3,
+        poison_spell=2,
+        rage_spell=2
+    )
+    await ctx.send(link)
 
 @bot.command()
 async def clan_info(ctx, clan_tag):
@@ -82,7 +119,7 @@ async def clan_info(ctx, clan_tag):
     except coc.NotFound:
         await ctx.send("This clan doesn't exist!")
         return
-        
+
     if clan.public_war_log is False:
         log = "Private"
     else:
@@ -90,21 +127,28 @@ async def clan_info(ctx, clan_tag):
 
     e = discord.Embed(colour=discord.Colour.green())
     e.set_thumbnail(url=clan.badge.url)
-    e.add_field(name="Clan Name", value=f"{clan.name}({clan.tag})\n[Open in game]({clan.share_link})", inline=False)
+    e.add_field(name="Clan Name",
+                value=f"{clan.name}({clan.tag})\n[Open in game]({clan.share_link})", inline=False)
     e.add_field(name="Clan Level", value=clan.level, inline=False)
     e.add_field(name="Description", value=clan.description, inline=False)
-    e.add_field(name="Leader", value=clan.get_member_by(role=coc.Role.leader), inline=False)
+    e.add_field(name="Leader", value=clan.get_member_by(
+        role=coc.Role.leader), inline=False)
     e.add_field(name="Clan Type", value=clan.type, inline=False)
     e.add_field(name="Location", value=clan.location, inline=False)
     e.add_field(name="Total Clan Trophies", value=clan.points, inline=False)
-    e.add_field(name="Total Clan Versus Trophies", value=clan.versus_points, inline=False)
+    e.add_field(name="Total Clan Versus Trophies",
+                value=clan.versus_points, inline=False)
     e.add_field(name="WarLog Type", value=log, inline=False)
-    e.add_field(name="Required Trophies", value=clan.required_trophies, inline=False)
+    e.add_field(name="Required Trophies",
+                value=clan.required_trophies, inline=False)
     e.add_field(name="War Win Streak", value=clan.war_win_streak, inline=False)
     e.add_field(name="War Frequency", value=clan.war_frequency, inline=False)
-    e.add_field(name="Clan War League Rank", value=clan.war_league, inline=False)
-    e.add_field(name="Clan Labels", value="\n".join(label.name for label in clan.labels), inline=False)
-    e.add_field(name="Member Count", value=f"{clan.member_count}/50", inline=False)
+    e.add_field(name="Clan War League Rank",
+                value=clan.war_league, inline=False)
+    e.add_field(name="Clan Labels", value="\n".join(
+        label.name for label in clan.labels), inline=False)
+    e.add_field(name="Member Count",
+                value=f"{clan.member_count}/50", inline=False)
     e.add_field(
         name="Clan Record",
         value=f"Won - {clan.war_wins}\nLost - {clan.war_losses}\n Draw - {clan.war_ties}",
@@ -124,11 +168,12 @@ async def clan_member(ctx, clan_tag):
     except coc.NotFound:
         await ctx.send("This clan does not exist!")
         return
-        
+
     member = ""
     for i, a in enumerate(clan.members, start=1):
         member += f"`{i}.` {a.name}\n"
-    embed = discord.Embed(colour=discord.Colour.red(), title=f"Members of {clan.name}", description=member)
+    embed = discord.Embed(colour=discord.Colour.red(),
+                          title=f"Members of {clan.name}", description=member)
     embed.set_thumbnail(url=clan.badge.url)
     embed.set_footer(text=f"Total Members - {clan.member_count}/50")
     await ctx.send(embed=embed)
@@ -158,8 +203,10 @@ async def current_war_status(ctx, clan_tag):
         minutes, seconds = divmod(remainder, 60)
 
         e.add_field(name=war.clan.name, value=war.clan.tag)
-        e.add_field(name="Opponent:", value=f"{war.opponent.name}\n" f"{war.opponent.tag}", inline=False)
-        e.add_field(name="War End Time:", value=f"{hours} hours {minutes} minutes {seconds} seconds", inline=False)
+        e.add_field(
+            name="Opponent:", value=f"{war.opponent.name}\n" f"{war.opponent.tag}", inline=False)
+        e.add_field(name="War End Time:",
+                    value=f"{hours} hours {minutes} minutes {seconds} seconds", inline=False)
 
     await ctx.send(embed=e)
 


### PR DESCRIPTION
`Solve Issue`: #79 
![1](https://user-images.githubusercontent.com/57266248/126778226-eb41f9d7-3c4e-49c9-b7f9-ab06f3ca8030.PNG)
![2](https://user-images.githubusercontent.com/57266248/126778233-38b5eb2b-bc79-499b-8faf-87cf92a60a3f.PNG)
![3](https://user-images.githubusercontent.com/57266248/126778234-a02b8ece-1cf6-4c45-8c5d-6138248655fa.PNG)
![4](https://user-images.githubusercontent.com/57266248/126778236-1ca24f74-4a77-4ad8-88a0-06441fdae86c.PNG)
- User can now give only troops or spells army link or if he wants then he can give both
- added examples(create_army, parse_army)
- added on_ready function in bot script