### PR TITLE
Allow coc.py to handle API requests for unlimited&uncached API endpoints

### DIFF
--- a/coc/client.py
+++ b/coc/client.py
@@ -138,6 +138,7 @@ class Client:
         "cache_max_size",
         "stats_max_size",
         "http",
+        "realtime",
         "_ready",
         "correct_tags",
         "load_game_data",
@@ -166,6 +167,7 @@ class Client:
         cache_max_size: int = 10000,
         stats_max_size: int = 1000,
         load_game_data: LoadGameData = LoadGameData(default=True),
+        realtime = False,
         **_,
     ):
 
@@ -186,6 +188,7 @@ class Client:
         self.stats_max_size = stats_max_size
 
         self.http = None  # set in method login()
+        self.realtime = realtime
         self.correct_tags = correct_tags
         self.load_game_data = load_game_data
 

--- a/coc/client.py
+++ b/coc/client.py
@@ -589,7 +589,12 @@ class Client:
             clan_tag = correct_tag(clan_tag)
 
         try:
-            data = await self.http.get_clan_current_war(clan_tag)
+            realtime = kwargs.get("realtime")
+        except KeyError:
+            realtime = None
+
+        try:
+            data = await self.http.get_clan_current_war(clan_tag, realtime=realtime)
         except Forbidden as exception:
             raise PrivateWarLog(exception.response, exception.reason) from exception
 
@@ -696,7 +701,12 @@ class Client:
             clan_tag = correct_tag(clan_tag)
 
         try:
-            data = await self.http.get_clan_war_league_group(clan_tag)
+            realtime = kwargs.get("realtime")
+        except KeyError:
+            realtime = None
+
+        try:
+            data = await self.http.get_clan_war_league_group(clan_tag, realtime=realtime)
         except Forbidden as exception:
             raise PrivateWarLog(exception.response, exception.reason) from exception
         except asyncio.TimeoutError:
@@ -744,7 +754,12 @@ class Client:
             war_tag = correct_tag(war_tag)
 
         try:
-            data = await self.http.get_cwl_wars(war_tag)
+            realtime = kwargs.get("realtime")
+        except KeyError:
+            realtime = None
+
+        try:
+            data = await self.http.get_cwl_wars(war_tag, realtime=realtime)
         except Forbidden as exception:
             raise PrivateWarLog(exception.response, exception.reason) from exception
 
@@ -872,7 +887,7 @@ class Client:
             return get_war
 
         try:
-            league_group = await self.get_league_group(clan_tag)
+            league_group = await self.get_league_group(clan_tag,**kwargs)
         except (NotFound, GatewayError) as exception:
             # either they're not in cwl (NotFound)
             # or it's an API bug where league group endpoint will timeout when the clan is searching (GatewayError)

--- a/coc/http.py
+++ b/coc/http.py
@@ -347,17 +347,17 @@ class HTTPClient:
 
     def get_clan_current_war(self, tag, realtime = None):
         return self.request(Route("GET", "/clans/{}/currentwar".format(tag) + (
-                                         '?realtime=true' if realtime or (not realtime and self.client.realtime)
+                                         '?realtime=true' if realtime or (realtime is None and self.client.realtime)
                                          else '')))
 
     def get_clan_war_league_group(self, tag, realtime = None):
         return self.request(Route("GET", "/clans/{}/currentwar/leaguegroup".format(tag) + (
-                                         '?realtime=true' if realtime or (not realtime and self.client.realtime)
+                                         '?realtime=true' if realtime or (realtime is None and self.client.realtime)
                                          else '')))
 
     def get_cwl_wars(self, war_tag, realtime = None):
         return self.request(Route("GET", "/clanwarleagues/wars/{}".format(war_tag) + (
-                                         '?realtime=true' if realtime or (not realtime and self.client.realtime)
+                                         '?realtime=true' if realtime or (realtime is None and self.client.realtime)
                                          else '')))
 
     # locations

--- a/coc/http.py
+++ b/coc/http.py
@@ -425,8 +425,7 @@ class HTTPClient:
         LOG.info("Successfully logged into the developer site.")
 
         resp_paylaod = await resp.json()
-        ip = json_loads(base64_b64decode(resp_paylaod["temporaryAPIToken"].split(".")[1] + "====").decode("utf-8"))[
-            "limits"][1]["cidrs"][0].split("/")[0]
+        ip = json_loads(base64_b64decode(resp_paylaod["temporaryAPIToken"].split(".")[1] + "====").decode("utf-8"))["limits"][1]["cidrs"][0].split("/")[0]
 
         LOG.info("Found IP address to be %s", ip)
 

--- a/coc/http.py
+++ b/coc/http.py
@@ -166,18 +166,18 @@ class HTTPClient:
 
     # pylint: disable=too-many-arguments, missing-docstring, protected-access, too-many-branches
     def __init__(
-        self,
-        client,
-        loop,
-        email,
-        password,
-        key_names,
-        key_count,
-        key_scopes,
-        throttle_limit,
-        throttler=BasicThrottler,
-        cache_max_size=10000,
-        stats_max_size=1000,
+            self,
+            client,
+            loop,
+            email,
+            password,
+            key_names,
+            key_count,
+            key_scopes,
+            throttle_limit,
+            throttler=BasicThrottler,
+            cache_max_size=10000,
+            stats_max_size=1000
     ):
         self.client = client
         self.loop = loop
@@ -187,7 +187,6 @@ class HTTPClient:
         self.key_count = key_count
         self.key_scopes = key_scopes
         self.throttle_limit = throttle_limit
-
         per_second = key_count * throttle_limit
 
         self.__session = None
@@ -226,7 +225,7 @@ class HTTPClient:
         url = route.url
 
         headers = {
-            "Accept": "application/json",
+            "Accept"       : "application/json",
             "authorization": "Bearer {}".format(next(self.keys)),
         }
         kwargs["headers"] = headers
@@ -237,7 +236,7 @@ class HTTPClient:
         cache_control_key = route.url
         cache = self.cache
         # the cache will be cleaned once it becomes stale / a new object is available from the api.
-        if cache is not None:
+        if cache is not None and not self.client.realtime:
             try:
                 return cache[cache_control_key]
             except KeyError:
@@ -261,7 +260,7 @@ class HTTPClient:
                             # set a callback to remove the item from cache once it's stale.
                             delta = int(response.headers["Cache-Control"].strip("max-age="))
                             data["_response_retry"] = delta
-                            if cache is not None:
+                            if cache is not None and not self.client.realtime:
                                 self.cache[cache_control_key] = data
                                 LOG.debug("Cache-Control max age: %s seconds, key: %s", delta, cache_control_key)
                                 self.loop.call_later(delta, self._cache_remove, cache_control_key)
@@ -294,8 +293,8 @@ class HTTPClient:
                             raise NotFound(response, data)
                         if response.status == 429:
                             LOG.error(
-                                "We have been rate-limited by the API. "
-                                "Reconsider the number of requests you are allowing per second."
+                                    "We have been rate-limited by the API. "
+                                    "Reconsider the number of requests you are allowing per second."
                             )
                             raise HTTPException(response, data)
 
@@ -347,13 +346,16 @@ class HTTPClient:
         return self.request(Route("GET", "/clans/{}/warlog".format(tag)))
 
     def get_clan_current_war(self, tag):
-        return self.request(Route("GET", "/clans/{}/currentwar".format(tag)))
+        return self.request(Route("GET", "/clans/{}/currentwar".format(tag) +
+                                         '?realtime=true' if self.client.realtime else ''))
 
     def get_clan_war_league_group(self, tag):
-        return self.request(Route("GET", "/clans/{}/currentwar/leaguegroup".format(tag)))
+        return self.request(Route("GET", "/clans/{}/currentwar/leaguegroup".format(tag) +
+                                         '?realtime=true' if self.client.realtime else ''))
 
     def get_cwl_wars(self, war_tag):
-        return self.request(Route("GET", "/clanwarleagues/wars/{}".format(war_tag)))
+        return self.request(Route("GET", "/clanwarleagues/wars/{}".format(war_tag) +
+                                         '?realtime=true' if self.client.realtime else ''))
 
     # locations
 
@@ -420,7 +422,8 @@ class HTTPClient:
         LOG.info("Successfully logged into the developer site.")
 
         resp_paylaod = await resp.json()
-        ip = json_loads(base64_b64decode(resp_paylaod["temporaryAPIToken"].split(".")[1] + "====").decode("utf-8"))["limits"][1]["cidrs"][0].split("/")[0]
+        ip = json_loads(base64_b64decode(resp_paylaod["temporaryAPIToken"].split(".")[1] + "====").decode("utf-8"))[
+            "limits"][1]["cidrs"][0].split("/")[0]
 
         LOG.info("Found IP address to be %s", ip)
 
@@ -433,17 +436,17 @@ class HTTPClient:
         if len(self._keys) < self.key_count:
             for key in (k for k in keys if k["name"] == self.key_names and ip not in k["cidrRanges"]):
                 LOG.info(
-                    "Deleting key with the name %s and IP %s (not matching our current IP address).",
-                    self.key_names, key["cidrRanges"],
+                        "Deleting key with the name %s and IP %s (not matching our current IP address).",
+                        self.key_names, key["cidrRanges"],
                 )
                 await session.post("https://developer.clashofclans.com/api/apikey/revoke", json={"id": key["id"]})
 
             while len(self._keys) < self.key_count and len(keys) < KEY_MAXIMUM:
                 data = {
-                    "name": self.key_names,
+                    "name"       : self.key_names,
                     "description": "Created on {}".format(datetime.now().strftime("%c")),
-                    "cidrRanges": [ip],
-                    "scopes": [self.key_scopes],
+                    "cidrRanges" : [ip],
+                    "scopes"     : [self.key_scopes],
                 }
 
                 LOG.info("Creating key with data %s.", str(data))
@@ -462,9 +465,9 @@ class HTTPClient:
         if len(self._keys) == 0:
             await self.close()
             raise RuntimeError(
-                "There are {} API keys already created and none match a key_name of '{}'."
-                "Please specify a key_name kwarg, or go to 'https://developer.clashofclans.com' to delete "
-                "unused keys.".format(len(keys), self.key_names)
+                    "There are {} API keys already created and none match a key_name of '{}'."
+                    "Please specify a key_name kwarg, or go to 'https://developer.clashofclans.com' to delete "
+                    "unused keys.".format(len(keys), self.key_names)
             )
 
         await session.close()

--- a/coc/http.py
+++ b/coc/http.py
@@ -345,17 +345,20 @@ class HTTPClient:
     def get_clan_warlog(self, tag):
         return self.request(Route("GET", "/clans/{}/warlog".format(tag)))
 
-    def get_clan_current_war(self, tag):
-        return self.request(Route("GET", "/clans/{}/currentwar".format(tag) +
-                                         '?realtime=true' if self.client.realtime else ''))
+    def get_clan_current_war(self, tag, realtime = None):
+        return self.request(Route("GET", "/clans/{}/currentwar".format(tag) + (
+                                         '?realtime=true' if realtime or (not realtime and self.client.realtime)
+                                         else '')))
 
-    def get_clan_war_league_group(self, tag):
-        return self.request(Route("GET", "/clans/{}/currentwar/leaguegroup".format(tag) +
-                                         '?realtime=true' if self.client.realtime else ''))
+    def get_clan_war_league_group(self, tag, realtime = None):
+        return self.request(Route("GET", "/clans/{}/currentwar/leaguegroup".format(tag) + (
+                                         '?realtime=true' if realtime or (not realtime and self.client.realtime)
+                                         else '')))
 
-    def get_cwl_wars(self, war_tag):
-        return self.request(Route("GET", "/clanwarleagues/wars/{}".format(war_tag) +
-                                         '?realtime=true' if self.client.realtime else ''))
+    def get_cwl_wars(self, war_tag, realtime = None):
+        return self.request(Route("GET", "/clanwarleagues/wars/{}".format(war_tag) + (
+                                         '?realtime=true' if realtime or (not realtime and self.client.realtime)
+                                         else '')))
 
     # locations
 


### PR DESCRIPTION
Pull request to allow the usage of the fast api aka the non cached version of the API. Added client attribute realtime as a global switch. Methods which are related to the fast api endpoints can manually switched back to the cached version by submitting a kwarg `realtime=False`