### PR TITLE
updates for tests to account for changed data

### DIFF
--- a/coc/miscmodels.py
+++ b/coc/miscmodels.py
@@ -345,7 +345,8 @@ class LegendStatistics:
             and self.best_season == other.best_season
             and self.current_season == other.current_season
             and self.best_versus_season == other.best_versus_season
-            and self.current_versus_season == other.current_versus_season
+            and self.previous_season == other.previous_season
+            and self.previous_versus_season == self.previous_versus_season
         )
 
     def __init__(self, *, data):

--- a/coc/players.py
+++ b/coc/players.py
@@ -282,14 +282,14 @@ class Player(ClanMember):
         self.troop_cls = Troop
         self.pet_cls = Pet
 
-        if self._client._troop_holder.loaded:
+        if self._client and self._client._troop_holder.loaded:
             self._game_files_loaded = True
         else:
             self._game_files_loaded = False
 
         if load_game_data is not None:
             self._load_game_data = load_game_data
-        elif self._client.load_game_data.never:
+        elif self._client and self._client.load_game_data.never:
             self._load_game_data = False
         else:
             self._load_game_data = True
@@ -319,10 +319,10 @@ class Player(ClanMember):
 
         label_cls = self.label_cls
         achievement_cls = self.achievement_cls
-        troop_loader = self._client._troop_holder.load
-        hero_loader =  self._client._hero_holder.load
-        spell_loader = self._client._spell_holder.load
-        pet_loader = self._client._pet_holder.load
+        troop_loader = self._client._troop_holder.load if self._client else None
+        hero_loader =  self._client._hero_holder.load if self._client else None
+        spell_loader = self._client._spell_holder.load if self._client else None
+        pet_loader = self._client._pet_holder.load if self._client else None
 
         if self._game_files_loaded:
             pet_lookup = [p.name for p in self._client._pet_holder.items]

--- a/tests/test_players.py
+++ b/tests/test_players.py
@@ -44,10 +44,10 @@ class TestClanMember(unittest.TestCase):
             self.assertEqual(member.clan_rank, case.get("clanRank"))
 
     def test_clan_previous_rank(self):
-        data = [{"clanPreviousRank": 14}, {"clanPreviousRank": 4}, {}]
+        data = [{"previousClanRank": 14}, {"previousClanRank": 4}, {}]
         for case in data:
             member = ClanMember(data=case, client=None)
-            self.assertEqual(member.clan_previous_rank, case.get("clanPreviousRank"))
+            self.assertEqual(member.clan_previous_rank, case.get("previousClanRank"))
 
     def test_donations(self):
         data = [{"donations": 55}, {"donations": 0}, {}]

--- a/tests/test_wars.py
+++ b/tests/test_wars.py
@@ -33,8 +33,8 @@ class TestWars(unittest.TestCase):
                 size = case["teamSize"]
                 self.assertIsInstance(war.team_size, int)
             except KeyError:
-                size = None
-                self.assertIsNone(war.team_size)
+                size = 0
+                self.assertEquals(war.team_size, 0)
             self.assertEqual(war.team_size, size)
 
     def test_start_times(self):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71307091/170845282-3dec5479-6823-4034-80b8-75d20da988eb.png)

Embarrassed this one took me so long to notice but since I had updated all of your tests I thought I would PR.

Initially this had been for #101 but I wanted to have all my tests passing before I began working on the issue. After I got all of the tests working I rented Sneaky Goblins on my account so that it would appear for my player. Upon doing this I noticed SG were in fact an elixer troop. So this #101 is actually not a real issue.