### PR TITLE
Client close function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,11 +47,14 @@ This example will get a player with a certain tag, and search for 5 clans with a
 
 .. code:: py
 
+    import asyncio
     import coc
 
-    client = coc.login('email', 'password')
-
     async def main():
+        # Create a login session
+        client = coc.Client()
+        await client.login("email", "password")
+
         player = await client.get_player("tag")
         print("{0.name} has {0.trophies} trophies!".format(player))
 
@@ -65,8 +68,14 @@ This example will get a player with a certain tag, and search for 5 clans with a
         except coc.PrivateWarLog:
             print("Uh oh, they have a private war log!")
 
-    client.loop.run_until_complete(main())
-    client.close()
+        # Make sure to close the session
+        await client.close_client()
+
+    if __name__ == '__main__':
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass
 
 Basic Events Example
 ---------------------

--- a/coc/client.py
+++ b/coc/client.py
@@ -278,13 +278,18 @@ class Client:
 
         LOG.debug("HTTP connection created. Client is ready for use.")
 
-    def close(self) -> None:
+    def close_loops(self) -> None:
         """Closes the HTTP connection
         """
         LOG.info("Clash of Clans client logging out...")
         self.dispatch("on_client_close")
         self.loop.run_until_complete(self.http.close())
         self.loop.close()
+
+    async def close_client(self) -> None:
+        """Closes the HTTP connection from within a loop function such as
+        async def main()"""
+        await self.http.close()
 
     def dispatch(self, event_name: str, *args, **kwargs) -> None:
         """Dispatches an event listener matching the `event_name` parameter."""

--- a/coc/client.py
+++ b/coc/client.py
@@ -289,6 +289,7 @@ class Client:
     async def close_client(self) -> None:
         """Closes the HTTP connection from within a loop function such as
         async def main()"""
+        LOG.info("Clash of Clans client logging out...")
         await self.http.close()
 
     def dispatch(self, event_name: str, *args, **kwargs) -> None:


### PR DESCRIPTION
#111 
[Added coc.Client.close_client coroutine] Added coroutine to allow us…ers to close the client connection from within a async function such as async main(). This is useful to allow users to use the `asyncio.run()` wrapper properly 