### PR TITLE
Clan injection bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+.idea/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/README.rst
+++ b/README.rst
@@ -47,11 +47,14 @@ This example will get a player with a certain tag, and search for 5 clans with a
 
 .. code:: py
 
+    import asyncio
     import coc
 
-    client = coc.login('email', 'password')
-
     async def main():
+        # Create a login session
+        client = coc.Client()
+        await client.login("email", "password")
+
         player = await client.get_player("tag")
         print("{0.name} has {0.trophies} trophies!".format(player))
 
@@ -65,8 +68,14 @@ This example will get a player with a certain tag, and search for 5 clans with a
         except coc.PrivateWarLog:
             print("Uh oh, they have a private war log!")
 
-    client.loop.run_until_complete(main())
-    client.close()
+        # Make sure to close the session
+        await client.close_client()
+
+    if __name__ == '__main__':
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass
 
 Basic Events Example
 ---------------------

--- a/coc/abc.py
+++ b/coc/abc.py
@@ -105,7 +105,7 @@ class BaseClan:
         if load_game_data and not isinstance(load_game_data, bool):
             raise TypeError("load_game_data must be either True or False.")
 
-        return PlayerIterator(self._client, (p.tag for p in self.members), cls=cls, load_game_data=load_game_data)
+        return PlayerIterator(self._client, (p.tag for p in self.members), cls=cls, load_game_data=load_game_data, members=self.members_dict)
 
 
 class BasePlayer:

--- a/coc/abc.py
+++ b/coc/abc.py
@@ -105,7 +105,11 @@ class BaseClan:
         if load_game_data and not isinstance(load_game_data, bool):
             raise TypeError("load_game_data must be either True or False.")
 
-        return PlayerIterator(self._client, (p.tag for p in self.members), cls=cls, load_game_data=load_game_data, members=self.members_dict)
+        return PlayerIterator(self._client,
+                              (p.tag for p in self.members),
+                              cls=cls,
+                              load_game_data=load_game_data,
+                              members=self.members_dict)
 
 
 class BasePlayer:

--- a/coc/clans.py
+++ b/coc/clans.py
@@ -25,7 +25,7 @@ import typing
 
 
 from .players import ClanMember
-from .miscmodels import try_enum, ChatLanguage, Location, Label, WarLeague
+from .miscmodels import try_enum, ChatLanguage, Location, Label, WarLeague, CapitalDistrict
 from .utils import get, cached_property, correct_tag
 from .abc import BaseClan
 
@@ -129,6 +129,9 @@ class Clan(BaseClan):
     member_cls: :class:`coc.ClanMember`
         The type which the members found in :attr:`Clan.members` will be of.
         Ensure any overriding of this inherits from :class:`coc.ClanMember`.
+    capital_district_cls: :class:`coc.CapitalDistrict`
+        The type which the clan capital districts found in :attr:`Clan.capital_districts` will be of.
+        Ensure any overriding of this inherits from :class:`coc.CapitalDistrict`.
     war_league: :class:`coc.WarLeague`
         The clan's CWL league.
     """
@@ -148,23 +151,29 @@ class Clan(BaseClan):
         "public_war_log",
         "member_count",
         "_labels",
+        "_members",
+        "_districts",
         "_client",
         "label_cls",
         "member_cls",
+        "capital_district_cls",
         "war_league",
         "chat_language",
 
         "_cs_labels",
         "_cs_members",
         "_cs_members_dict",
+        "_cs_capital_districts",
         "_iter_labels",
         "_iter_members",
+        "_iter_capital_districts"
     )
 
     def __init__(self, *, data, client, **_):
         super().__init__(data=data, client=client)
         self.label_cls = Label
         self.member_cls = ClanMember
+        self.capital_district_cls = CapitalDistrict
 
         self._from_data(data)
 
@@ -198,6 +207,13 @@ class Clan(BaseClan):
             member_cls(data=mdata, client=self._client, clan=self) for mdata in data_get("memberList", [])
         )
 
+        capital_district_cls = self.capital_district_cls
+        if data_get("clanCapital"):
+            self._iter_capital_districts = (capital_district_cls(data=cddata, client=self._client) for cddata in
+                                            data_get("clanCapital")["districts"])
+        else:
+            self._iter_capital_districts = ()
+
     @cached_property("_cs_labels")
     def labels(self) -> typing.List[Label]:
         """List[:class:`Label`]: A :class:`List` of :class:`Label` that the clan has."""
@@ -213,6 +229,11 @@ class Clan(BaseClan):
         """Dict[str, :class:`ClanMember`]: A dict of members that belong to the clan."""
         return {m.tag: m for m in self._iter_members}
 
+
+    @cached_property("_cs_capital_districts")
+    def capital_districts(self) -> typing.List[CapitalDistrict]:
+        """List[:class:`CapitalDistrict`]: A :class:`List` of :class:`CapitalDistrict` that the clan has."""
+        return list(self._iter_capital_districts)
 
     def get_member(self, tag: str) -> typing.Optional[ClanMember]:
         """Return a :class:`ClanMember` with the tag provided. Returns ``None`` if not found.

--- a/coc/clans.py
+++ b/coc/clans.py
@@ -148,7 +148,6 @@ class Clan(BaseClan):
         "public_war_log",
         "member_count",
         "_labels",
-        "_members",
         "_client",
         "label_cls",
         "member_cls",
@@ -157,6 +156,7 @@ class Clan(BaseClan):
 
         "_cs_labels",
         "_cs_members",
+        "_cs_members_dict",
         "_iter_labels",
         "_iter_members",
     )
@@ -165,8 +165,6 @@ class Clan(BaseClan):
         super().__init__(data=data, client=client)
         self.label_cls = Label
         self.member_cls = ClanMember
-
-        self._members = None  # type: typing.Optional[typing.Dict[str, ClanMember]]
 
         self._from_data(data)
 
@@ -208,8 +206,13 @@ class Clan(BaseClan):
     @cached_property("_cs_members")
     def members(self) -> typing.List[ClanMember]:
         """List[:class:`ClanMember`]: A list of members that belong to the clan."""
-        dict_members = self._members = {m.tag: m for m in self._iter_members}
-        return list(dict_members.values())
+        return list(self.members_dict.values())
+
+    @cached_property("_cs_members_dict")
+    def members_dict(self) -> typing.Dict[str, ClanMember]:
+        """Dict[str, :class:`ClanMember`]: A dict of members that belong to the clan."""
+        return {m.tag: m for m in self._iter_members}
+
 
     def get_member(self, tag: str) -> typing.Optional[ClanMember]:
         """Return a :class:`ClanMember` with the tag provided. Returns ``None`` if not found.
@@ -226,11 +229,11 @@ class Clan(BaseClan):
         The member who matches the tag provided: Optional[:class:`ClanMember`]
         """
         tag = correct_tag(tag)
-        if not self._members:
+        if not self.members_dict:
             _ = self.members
 
         try:
-            return self._members[tag]
+            return self.members_dict[tag]
         except KeyError:
             return None
 

--- a/coc/client.py
+++ b/coc/client.py
@@ -278,13 +278,18 @@ class Client:
 
         LOG.debug("HTTP connection created. Client is ready for use.")
 
-    def close(self) -> None:
+    def close_loops(self) -> None:
         """Closes the HTTP connection
         """
         LOG.info("Clash of Clans client logging out...")
         self.dispatch("on_client_close")
         self.loop.run_until_complete(self.http.close())
         self.loop.close()
+
+    async def close_client(self) -> None:
+        """Closes the HTTP connection from within a loop function such as
+        async def main()"""
+        await self.http.close()
 
     def dispatch(self, event_name: str, *args, **kwargs) -> None:
         """Dispatches an event listener matching the `event_name` parameter."""

--- a/coc/events.py
+++ b/coc/events.py
@@ -724,7 +724,7 @@ class EventsClient(Client):
         tasks = {t for t in asyncio.Task.all_tasks(loop=self.loop) if not t.done()}
         for task in tasks:
             task.cancel()
-        super().close()
+        super().close_loops()
 
     def dispatch(self, event_name: str, *args, **kwargs):
         # pylint: disable=broad-except

--- a/coc/miscmodels.py
+++ b/coc/miscmodels.py
@@ -580,6 +580,40 @@ class Label:
         self.badge = try_enum(Icon, data=data.get("iconUrls"), client=self._client)
 
 
+class CapitalDistrict:
+    """Represents a Clan Capital District.
+
+    Attributes
+    -----------
+    id:
+        :class:`int`: The district's unique ID as given by the API.
+    name:
+        :class:`str`: The district's name.
+    hall_level:
+        :class:`int`: The district's hall level
+    """
+
+    __slots__ = ("id", "name", "_client", "hall_level")
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        attrs = [("id", self.id), ("name", self.name)]
+        return "<%s %s>" % (self.__class__.__name__, " ".join("%s=%r" % t for t in attrs),)
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.id == other.id
+
+    def __init__(self, *, data, client):
+        # pylint: disable=invalid-name
+        self._client = client
+
+        self.id: int = data.get("id")
+        self.name: str = data.get("name")
+        self.hall_level: int = data.get("districtHallLevel")
+
+
 class WarLeague:
     """Represents a clan's CWL league.
     Attributes

--- a/coc/players.py
+++ b/coc/players.py
@@ -208,6 +208,8 @@ class Player(ClanMember):
         The player's best versus trophy count.
     versus_attack_wins: :class:`int`
         The number of versus attacks the player has won
+    clan_capital_contributions: :class:`int`
+        The player's total contribution to clan capitals
     legend_statistics: Optional[:class:`LegendStatistics`]
         The player's legend statistics, or ``None`` if they have never been in the legend league.
     war_opted_in: Optional[:class:`bool`]
@@ -226,6 +228,7 @@ class Player(ClanMember):
         "builder_hall",
         "best_versus_trophies",
         "versus_attack_wins",
+        "clan_capital_contributions",
         "legend_statistics",
         "war_opted_in",
         "_achievements",
@@ -309,6 +312,7 @@ class Player(ClanMember):
         self.builder_hall: int = data_get("builderHallLevel", 0)
         self.best_versus_trophies: int = data_get("bestVersusTrophies")
         self.versus_attack_wins: int = data_get("versusBattleWins")
+        self.clan_capital_contributions: int = data_get("clanCapitalContributions")
         self.legend_statistics = try_enum(LegendStatistics, data=data_get("legendStatistics"))
 
         try:

--- a/examples/war_logs.py
+++ b/examples/war_logs.py
@@ -47,4 +47,4 @@ async def get_warlog_opponents_from_clan_name(name: str, no_of_clans: int):
 
 if __name__ == "__main__":
     client.loop.run_until_complete(get_warlog_opponents_from_clan_name("name", 5))
-    client.close()
+    client.close_loops()


### PR DESCRIPTION
Fixes issue #109 

I added a new attribute to coc.Clan

```py
@cached_property("_cs_members_dict")
def members_dict(self) -> typing.Dict[str, ClanMember]:
    """Dict[str, :class:`ClanMember`]: A dict of members that belong to the clan."""
    return {m.tag: m for m in self._iter_members}
```

This gives the Player iterator object access to the dictionary of clan members

```py
return PlayerIterator(self._client, 
                      (p.tag for p in self.members), 
                      cls=cls, 
                      load_game_data=load_game_data, 
                      members=self.members_dict)
```