### PR TITLE
fix the docs

### DIFF
--- a/coc/__init__.py
+++ b/coc/__init__.py
@@ -75,7 +75,10 @@ from .miscmodels import (
     TimeDelta,
     Label,
     WarLeague,
+    GoldPassSeason,
+    ChatLanguage
 )
+from .entry_logs import LogPaginator, ClanWarLog, RaidLog
 from .players import Player, ClanMember, RankedPlayer
 from .player_clan import PlayerClan
 from .spell import Spell
@@ -85,3 +88,4 @@ from .war_attack import WarAttack
 from .war_members import ClanWarLeagueClanMember, ClanWarMember
 from .wars import ClanWar, ClanWarLogEntry, ClanWarLeagueGroup
 from . import utils
+from .raid import RaidLogEntry, RaidClan, RaidMember, RaidAttack, RaidDistrict

--- a/coc/hero.py
+++ b/coc/hero.py
@@ -52,6 +52,9 @@ class Hero(DataContainer):
     village: str
         Either ``home`` or ``builderBase``, indicating which village this hero belongs to.
     """
+    __slots__ = ("id", "name", "range", "dps", "hitpoints", "ground_target", "speed", "upgrade_cost",
+                 "upgrade_time", "ability_time", "required_th_level", "regeneration_time", "level",
+                 "max_level", "village")
     name: str
     level: int
     max_level: int
@@ -140,6 +143,8 @@ class Pet(DataContainer):
     village: str
         Either ``home`` or ``builderBase``, indicating which village this pet belongs to.
     """
+    __slots__ = ("id", "name", "range", "dps", "ground_target", "hitpoints", "speed", "upgrade_cost",
+                 "upgrade_resource", "upgrade_time", "level", "max_level", "village")
     name: str
     level: int
     max_level: int

--- a/coc/raid.py
+++ b/coc/raid.py
@@ -28,10 +28,6 @@ from . import BasePlayer
 from .miscmodels import Badge, Timestamp, try_enum
 from .utils import cached_property, correct_tag
 
-if TYPE_CHECKING:
-    # pylint: disable=cyclic-import
-    from .war_members import ClanWarMember  # noqa
-
 
 class RaidMember(BasePlayer):
     """Represents a Raid Member that the API returns.

--- a/coc/spell.py
+++ b/coc/spell.py
@@ -47,6 +47,9 @@ class Spell(DataContainer):
     village: str
         Either ``home`` or ``builderBase``, indicating which village this spell belongs to.
     """
+    __slots__ = ("id", "name", "range", "upgrade_cost", "upgrade_resource", "upgrade_time",
+                 "training_cost", "training_resource", "training_time", "is_siege_machine", "level", "max_level",
+                 "village")
     name: str
     level: int
     max_level: int

--- a/coc/troop.py
+++ b/coc/troop.py
@@ -37,13 +37,13 @@ class Troop(DataContainer):
     +----------------------------------+-------------------+
     |  :attr:`Troop.upgrade_resource`  | :class:`Resource` |
     +----------------------------------+-------------------+
-    |    :attr:`Troop.upgrade_time`    |   :class:`TimeDelta`   |
+    |    :attr:`Troop.upgrade_time`    | :class:`TimeDelta`|
     +----------------------------------+-------------------+
     |   :attr:`Troop.training_cost`    |        int        |
     +----------------------------------+-------------------+
     | :attr:`Troop.training_resource`  | :class:`Resource` |
     +----------------------------------+-------------------+
-    |   :attr:`Troop.training_time`    |   :class:`TimeDelta`   |
+    |   :attr:`Troop.training_time`    |:class:`TimeDelta` |
     +----------------------------------+-------------------+
     |  :attr:`Troop.is_elixir_troop`   |   :class:`bool`   |
     +----------------------------------+-------------------+
@@ -53,9 +53,9 @@ class Troop(DataContainer):
     +----------------------------------+-------------------+
     |   :attr:`Troop.is_super_troop`   |   :class:`bool`   |
     +----------------------------------+-------------------+
-    |      :attr:`Troop.cooldown`      |   :class:`TimeDelta`   |
+    |      :attr:`Troop.cooldown`      | :class:`TimeDelta`|
     +----------------------------------+-------------------+
-    |      :attr:`Troop.duration`      |   :class:`TimeDelta`   |
+    |      :attr:`Troop.duration`      | :class:`TimeDelta`|
     +----------------------------------+-------------------+
     | :attr:`Troop.min_original_level` |        int        |
     +----------------------------------+-------------------+
@@ -127,6 +127,9 @@ class Troop(DataContainer):
     village: str
         Either ``home`` or ``builderBase``, indicating which village this troop belongs to.
     """
+    __slots__ = ("id", "name", "range", "lab_level", "dps", "hitpoints", "ground_traget", "speed", "upgrade_cost",
+                 "upgrade_resource", "upgrade_time", "training_cost", "training_resource", "training_time",
+                 "cooldown", "duration", "min_original_level", "original_troop", "level", "max_level", "village")
     name: str
     level: int
     max_level: int

--- a/docs/code_overview/event.rst
+++ b/docs/code_overview/event.rst
@@ -242,6 +242,7 @@ A few points to note:
 - Tags will be automatically corrected via the :meth:`coc.correct_tag` function.
 
 - **Every tag** that is added to the client will be sent to **every callback for that event group**.
+
 This makes for a much simpler internal design.
 
 

--- a/docs/code_overview/game_data.rst
+++ b/docs/code_overview/game_data.rst
@@ -1,5 +1,6 @@
 .. currentmodule:: coc
 .. _game_data:
+
 Game Data
 =========
 The following provides a detailed how-to for use of static game data that is loaded into coc.py.
@@ -22,6 +23,7 @@ Additionally, speed and memory consumption has been prioritised and optimised wh
 
 
 .. _initialising_game_data:
+
 Initialising the Client
 -----------------------
 
@@ -82,6 +84,7 @@ Although all efforts have been made to minimise overheads, some may prefer to on
 
 
 .. _loading_game_data:
+
 Loading Game Data Manually
 --------------------------
 
@@ -125,6 +128,7 @@ won't have metadata loaded. This is easy to fix, with the :meth:`Player.load_gam
 
 
 .. _initiated_v_uninitiated:
+
 Initiated vs Uninitiated Objects
 --------------------------------
 
@@ -138,6 +142,7 @@ with attributes.
 
 
 .. _initiated_objects:
+
 Initiated Objects
 ~~~~~~~~~~~~~~~~~
 
@@ -197,6 +202,7 @@ Alternatively, you could use :meth:`Client.get_troop` and use the unititiated ob
 
 
 .. _uninitiated_objects:
+
 Uninitiated Objects
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/code_overview/models.rst
+++ b/docs/code_overview/models.rst
@@ -27,6 +27,13 @@ Player Clan
     :private-members:
     :inherited-members:
 
+Raid Clan
+^^^^^^^^^
+.. autoclass:: RaidClan()
+    :members:
+    :private-members:
+    :inherited-members:
+
 Ranked Clan
 ^^^^^^^^^^^
 .. autoclass:: RankedClan()
@@ -74,7 +81,7 @@ Clan Member
     :inherited-members:
 
 Ranked Player
-^^^^^^^^^^^
+^^^^^^^^^^^^^
 .. autoclass:: RankedPlayer()
     :members:
     :private-members:
@@ -90,6 +97,13 @@ Clan War League Clan Member
 Clan War Member
 ^^^^^^^^^^^^^^^
 .. autoclass:: ClanWarMember()
+    :members:
+    :private-members:
+    :inherited-members:
+
+Raid Member
+^^^^^^^^^^^
+.. autoclass:: RaidMember()
     :members:
     :private-members:
     :inherited-members:
@@ -135,6 +149,30 @@ WarAttack
     :private-members:
 
 
+Raids
+~~~~~~
+
+Raid Log Entry
+^^^^^^^^^^^^^^
+.. autoclass:: RaidLogEntry()
+    :members:
+    :private-members:
+    :inherited-members:
+
+Raid District
+^^^^^^^^^^^^^
+.. autoclass:: RaidDistrict()
+    :members:
+    :private-members:
+    :inherited-members:
+
+Raid Attack
+~~~~~~~~~~~~
+.. autoclass:: RaidAttack()
+    :members:
+    :private-members:
+
+
 Achievement
 ~~~~~~~~~~~~
 
@@ -152,15 +190,20 @@ Troop
 
 Hero
 ~~~~~
-
 .. autoclass:: Hero()
+    :members:
+    :private-members:
+
+
+Pet
+~~~~
+.. autoclass:: Pet()
     :members:
     :private-members:
 
 
 Spell
 ~~~~~~
-
 .. autoclass:: Spell()
     :members:
     :private-members:
@@ -168,7 +211,6 @@ Spell
 
 Location
 ~~~~~~~~~
-
 .. autoclass:: Location()
     :members:
     :private-members:
@@ -229,6 +271,13 @@ War League
 .. autoclass:: WarLeague()
     :members:
     :private-members:
+
+Gold pass season
+~~~~~~~~~~~~~~~~~
+.. autoclass:: GoldPassSeason()
+    :members:
+    :private-members:
+    :inherited-members:
 
 Enumerations
 ~~~~~~~~~~~~

--- a/docs/discord-links/api-reference.rst
+++ b/docs/discord-links/api-reference.rst
@@ -1,4 +1,4 @@
-.. current-module:: coc
+.. currentmodule:: coc
 
 API Reference
 =============

--- a/docs/discord-links/discord-links-examples.rst
+++ b/docs/discord-links/discord-links-examples.rst
@@ -1,4 +1,4 @@
-.. current-module:: coc
+.. currentmodule:: coc
 
 Examples
 ========

--- a/docs/discord-links/overview.rst
+++ b/docs/discord-links/overview.rst
@@ -1,4 +1,4 @@
-.. current-module:: coc
+.. currentmodule:: coc
 
 .. _links_extension:
 

--- a/docs/examples/discord_bot.rst
+++ b/docs/examples/discord_bot.rst
@@ -1,4 +1,4 @@
-.. current-module:: coc
+.. currentmodule:: coc
 
 Discord Bot
 ===========

--- a/docs/examples/events_example.rst
+++ b/docs/examples/events_example.rst
@@ -1,10 +1,10 @@
-.. current-module:: coc
+.. currentmodule:: coc
 
 Events
 ======
 This is an example of a basic events setup.
 
-.. literalinclude:: ../../examples/events.py
+.. literalinclude:: ../../examples/events_example.py
    :language: py
    :linenos:
    :lines: 1-126,138-

--- a/docs/examples/war_logs.rst
+++ b/docs/examples/war_logs.rst
@@ -1,4 +1,4 @@
-.. current-module:: coc
+.. currentmodule:: coc
 
 War Logs
 ========

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,6 @@ coc.py: A Clash of Clans API Wrapper
    :caption: Examples
 
    examples/discord_bot
-   examples/discord_links
    examples/events_example
    examples/war_logs
 

--- a/docs/miscellaneous/changelog.rst
+++ b/docs/miscellaneous/changelog.rst
@@ -107,8 +107,8 @@ v1.0.3
 
 - Fixed an issue where the HTTP cache layer was not being utilised.
 
-- Fixed an issue where :meth:`utils.get_season_start` and :meth:`utils.get_season_end` got the previous season information
-if the system time had not yet passed 5am UTC.
+- Fixed an issue where :meth:`utils.get_season_start` and :meth:`utils.get_season_end` got the previous season information if the system time had not yet passed 5am UTC.
+
 
 
 v1.0.2
@@ -124,8 +124,7 @@ v1.0.2
 v1.0.1
 ------
 
-- Maintenance event poller logic has been reworked to enable the use of :class:`EventsClient` without any player/clan/war
-updates.
+- Maintenance event poller logic has been reworked to enable the use of :class:`EventsClient` without any player/clan/war updates.
 
 - 5min preparation time has been included in the list of valid prep times for friendly wars.
 

--- a/docs/miscellaneous/migrating_to_v2.rst
+++ b/docs/miscellaneous/migrating_to_v2.rst
@@ -50,8 +50,7 @@ More on that in the :ref:`game_data` section, however.
 
 Miscellaneous
 -------------
-- ``ujson`` has been added to the requirements and will be used where possible,
-as a faster method of deserialising json payloads from the API.
+- ``ujson`` has been added to the requirements and will be used where possible, as a faster method of deserialising json payloads from the API.
 
 - Internal handling of keys has been written to make it more stable.
 

--- a/examples/war_logs.py
+++ b/examples/war_logs.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import traceback
 
 import coc
 from coc.raid import RaidLogEntry
@@ -20,36 +21,36 @@ async def get_warlog_for_clans(client: coc.Client, clan_tags: list):
     return war_logs
 
 
-async def test_raidlog(client: coc.Client, clan_tag: str):
+async def test_raidlog(client: coc.Client, clan_tag: str, page_limit: int = None):
     # Limit is set to None retrieving all values
     raid_no_page = await client.get_raidlog(clan_tag)
     limit = len(raid_no_page)
-    page_limit = 30
+    page_limit = page_limit or 10
 
     # Enable pagination, by default it will only cache 10 logs using limit
     # once you iterate beyond the cached amount, it will fetch the next set
     raid_with_page = await client.get_raidlog(clan_tag, page=True, limit=page_limit)
 
     # Iterate over warlogs like the current version of coc.py
-    for i, e in enumerate(raid_no_page):
-        e: RaidLogEntry
-        print(f"[{i}]-sync limit: {limit} page: False {e.start_time.time}")
-
-    # Option to async for loop a non paginated object
-    count = 0
-    async for i in raid_no_page:
-        print(f"[{count}]-async limit: {limit} page: False")
-        count += 1
-
-    for i, e in enumerate(raid_with_page):
-        print(f"[{i}]-sync limit: {page_limit} page: True")
-
-    # Set `paginate=True` to enable fetching beyond the limit value until
-    # there are more values to fetch
-    count = 0
-    async for i in raid_with_page:
-        print(f"[{count}]-async limit: {page_limit} page: True {i.start_time.time}")
-        count += 1
+    # for i, e in enumerate(raid_no_page):
+    #     e: RaidLogEntry
+    #     print(f"[{i}]-sync limit: {limit} page: False {e.start_time.time}")
+    #
+    # # Option to async for loop a non paginated object
+    # count = 0
+    # async for i in raid_no_page:
+    #     print(f"[{count}]-async limit: {limit} page: False")
+    #     count += 1
+    #
+    # for i, e in enumerate(raid_with_page):
+    #     print(f"[{i}]-sync limit: {page_limit} page: True")
+    #
+    # # Set `paginate=True` to enable fetching beyond the limit value until
+    # # there are more values to fetch
+    # count = 0
+    # async for i in raid_with_page:
+    #     print(f"[{count}]-async limit: {page_limit} page: True {i.start_time.time}")
+    #     count += 1
 
 
     # Simple test comparing the two data sets
@@ -59,36 +60,36 @@ async def test_raidlog(client: coc.Client, clan_tag: str):
             raise AssertionError(f"{id(async_log)} does not match {id(raid_no_page[count])} at index {count}")
         count += 1
 
-async def test_warlog(client: coc.Client, clan_tag: str):
+async def test_warlog(client: coc.Client, clan_tag: str, page_limit: int = None):
 
     # Limit is set to None retrieving all values
     warlogs_no_page = await client.get_warlog(clan_tag)
     limit = len(warlogs_no_page)
-    pagination_limit = 11
+    pagination_limit = page_limit or 10
 
     # Enable pagination, by default it will only cache 10 logs using limit
     # once you iterate beyond the cached amount, it will fetch the next set
     warlogs_with_page = await client.get_warlog(clan_tag, page=True, limit=pagination_limit)
 
     # Iterate over warlogs like the current version of coc.py
-    for i, e in enumerate(warlogs_no_page):
-        print(f"[{i}]-sync limit: {limit} page: False")
-
-    # Option to async for loop a non paginated object
-    count = 0
-    async for i in warlogs_no_page:
-        print(f"[{count}]-async limit: {limit} page: False")
-        count += 1
-
-    for i, e in enumerate(warlogs_with_page):
-        print(f"[{i}]-sync limit: {pagination_limit} page: True")
-
-    # Set `paginate=True` to enable fetching beyond the limit value until
-    # there are more values to fetch
-    count = 0
-    async for i in warlogs_with_page:
-        print(f"[{count}]-async limit: {pagination_limit} page: True {i.end_time.time}")
-        count += 1
+    # for i, e in enumerate(warlogs_no_page):
+    #     print(f"[{i}]-sync limit: {limit} page: False")
+    #
+    # # Option to async for loop a non paginated object
+    # count = 0
+    # async for i in warlogs_no_page:
+    #     print(f"[{count}]-async limit: {limit} page: False")
+    #     count += 1
+    #
+    # for i, e in enumerate(warlogs_with_page):
+    #     print(f"[{i}]-sync limit: {pagination_limit} page: True")
+    #
+    # # Set `paginate=True` to enable fetching beyond the limit value until
+    # # there are more values to fetch
+    # count = 0
+    # async for i in warlogs_with_page:
+    #     print(f"[{count}]-async limit: {pagination_limit} page: True {i.end_time.time}")
+    #     count += 1
 
     # Simple test comparing the two data sets
     count = 0
@@ -127,14 +128,21 @@ async def get_warlog_opponents_from_clan_name(client: coc.Client, name: str, no_
 async def main():
     async with coc.Client() as coc_client:
         try:
-            await coc_client.login(os.environ.get("DEV_SITE_EMAIL"),
-                                   os.environ.get("DEV_SITE_PASSWORD"))
+            await coc_client.login("lukas.dobler@gmx.de", "Kaktus_2015")
         except coc.InvalidCredentials as error:
             exit(error)
 
         await get_warlog_opponents_from_clan_name(coc_client, "Reddit Zulu", 5)
-        await test_warlog(coc_client, "#2Y28CGP8")
-        await test_raidlog(coc_client, "#2Y28CGP8")
+        for i in range(2, 16):
+            try:
+                await test_warlog(coc_client, "#2Y28CGP8", i)
+                await test_raidlog(coc_client, "#2Y28CGP8", i)
+            except Exception:
+                print(i)
+                traceback.print_exc()
+                continue
+        print(f'success {i}')
+    await asyncio.sleep(10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tried to reduce the number of warnings. from over 100 down to 33 with sphinx. About the remaining ones I have no glue. There is something wrong with the imports. All of them llok like this:
```
/home/doluk/coc.py/coc/players.py:docstring of coc.players.Player:1: WARNING: autosummary: failed to import Player.spells.
Possible hints:
* ModuleNotFoundError: No module named 'coc.Player'
* KeyError: 'Player'
* AttributeError: 'NoneType' object has no attribute '_iter_spells'
* AttributeError: type object 'Player' has no attribute 'Player'
* ImportError:
* ModuleNotFoundError: No module named 'Player'
```
or this:
```
/home/doluk/coc.py/docs/code_overview/game_data.rst:49: WARNING: undefined label: 'manually_loading_metadata'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:177: WARNING: undefined label: 'on_clan_member_trophy_change'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:177: WARNING: undefined label: 'on_clan_member_versus_trophy_change'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:177: WARNING: undefined label: 'on_clan_member_league_change'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:190: WARNING: undefined label: 'on_war_state_change'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:197: WARNING: undefined label: 'on_clan_member_join'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:242: WARNING: undefined label: 'on_player_clan_join'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:243: WARNING: undefined label: 'on_player_clan_leave'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:244: WARNING: undefined label: 'on_player_clan_level_change'
/home/doluk/coc.py/docs/miscellaneous/changelog.rst:245: WARNING: undefined label: 'on_player_clan_badge_change'
```