### PR TITLE
Fix a bug for clients with realtime access

### DIFF
--- a/coc/client.py
+++ b/coc/client.py
@@ -190,6 +190,8 @@ class Client:
 
         self.http = None  # set in method login()
         self.realtime = realtime
+        if realtime and self.key_scopes == "clash":
+            self.key_scopes = 'clash:*:verifytoken,realtime' # without that the key creation will fail due to the wrong scopes.
         self.correct_tags = correct_tags
         self.load_game_data = load_game_data
 


### PR DESCRIPTION
The wrong scope prevented the key creation with  email and password and force the users to login with keys