### PR TITLE
Fix for only one raid per clan showing on atk/def log

### DIFF
--- a/coc/raid.py
+++ b/coc/raid.py
@@ -407,11 +407,14 @@ class RaidLogEntry:
                  "_attack_log",
                  "_defense_log",
                  "_client",
-                 "_response_retry")
+                 "_response_retry",
+                 "_raw_data"
+                 )
 
     def __init__(self, *, data, client, **_):
         self._client = client
         self._response_retry = data.get("_response_retry")
+        self._raw_data = data
         self._from_data(data)
         self._members = {}
         self._attack_log = []
@@ -470,15 +473,15 @@ class RaidLogEntry:
     def attack_log(self) -> typing.List[RaidClan]:
         """List[:class:`RaidClan`]: A list of raid clans that are attacked in the raid season.
         """
-        dict_attack_log = self._attack_log = {m.tag: m for m in self._iter_attack_log}
-        return list(dict_attack_log.values())
+        list_attack_log = self._attack_log = [m for m in self._iter_attack_log]
+        return list_attack_log
 
     @cached_property("_cs_defense_log")
     def defense_log(self) -> typing.List[RaidClan]:
         """List[:class:`RaidClan`]: A list of raid clans which represents all the defensive raids of a season.
         """
-        dict_defense_log = self._defense_log = {m.tag: m for m in self._iter_defense_log}
-        return list(dict_defense_log.values())
+        list_defense_log = self._defense_log = [m for m in self._iter_defense_log]
+        return list_defense_log
 
     def get_member(self, tag: str) -> typing.Optional[RaidMember]:
         """Get a member of the clan for the given tag, or ``None`` if not found.

--- a/coc/raid.py
+++ b/coc/raid.py
@@ -407,14 +407,12 @@ class RaidLogEntry:
                  "_attack_log",
                  "_defense_log",
                  "_client",
-                 "_response_retry",
-                 "_raw_data"
+                 "_response_retry"
                  )
 
     def __init__(self, *, data, client, **_):
         self._client = client
         self._response_retry = data.get("_response_retry")
-        self._raw_data = data
         self._from_data(data)
         self._members = {}
         self._attack_log = []


### PR DESCRIPTION
Due to the attack & defense log using a dict, when an attack/defense was assigned to the key, it would replace the previous attack or defense, common in higher clan capital clans where they can attack or defend the same clan multiple times.