### PR TITLE
Add trigger extension

### DIFF
--- a/coc/ext/triggers/__init__.py
+++ b/coc/ext/triggers/__init__.py
@@ -1,7 +1,7 @@
 """An extension that provides decorators to facilitate automated, periodic repetition of functions."""
 
 
-from cron import CronSchedule, CronParserError
-from triggers import CronTrigger, IntervalTrigger
+from .cron import CronSchedule, CronParserError
+from .triggers import CronTrigger, IntervalTrigger, on_error
 
-__all__ = ['CronParserError', 'CronSchedule', 'CronTrigger', 'IntervalTrigger']
+__all__ = ['CronParserError', 'CronSchedule', 'CronTrigger', 'IntervalTrigger', 'on_error']

--- a/coc/ext/triggers/__init__.py
+++ b/coc/ext/triggers/__init__.py
@@ -2,6 +2,14 @@
 
 
 from .cron import CronSchedule, CronParserError
-from .triggers import CronTrigger, IntervalTrigger, on_error, start_triggers
+from .triggers import BaseTrigger, CronTrigger, IntervalTrigger, on_error, start_triggers
 
-__all__ = ['CronParserError', 'CronSchedule', 'CronTrigger', 'IntervalTrigger', 'on_error', 'start_triggers']
+__all__ = [
+    'BaseTrigger',
+    'CronParserError',
+    'CronSchedule',
+    'CronTrigger',
+    'IntervalTrigger',
+    'on_error',
+    'start_triggers'
+]

--- a/coc/ext/triggers/__init__.py
+++ b/coc/ext/triggers/__init__.py
@@ -1,6 +1,7 @@
 """An extension that provides decorators to facilitate automated, periodic repetition of functions."""
 
 
-from triggers import IntervalTrigger
+from cron import CronSchedule, CronParserError
+from triggers import CronTrigger, IntervalTrigger
 
-__all__ = ['IntervalTrigger']
+__all__ = ['CronParserError', 'CronSchedule', 'CronTrigger', 'IntervalTrigger']

--- a/coc/ext/triggers/__init__.py
+++ b/coc/ext/triggers/__init__.py
@@ -2,6 +2,6 @@
 
 
 from .cron import CronSchedule, CronParserError
-from .triggers import CronTrigger, IntervalTrigger, on_error
+from .triggers import CronTrigger, IntervalTrigger, on_error, start_triggers
 
-__all__ = ['CronParserError', 'CronSchedule', 'CronTrigger', 'IntervalTrigger', 'on_error']
+__all__ = ['CronParserError', 'CronSchedule', 'CronTrigger', 'IntervalTrigger', 'on_error', 'start_triggers']

--- a/coc/ext/triggers/__init__.py
+++ b/coc/ext/triggers/__init__.py
@@ -1,0 +1,6 @@
+"""An extension that provides decorators to facilitate automated, periodic repetition of functions."""
+
+
+from triggers import IntervalTrigger
+
+__all__ = ['IntervalTrigger']

--- a/coc/ext/triggers/cron.py
+++ b/coc/ext/triggers/cron.py
@@ -180,7 +180,7 @@ class CronSchedule:
                                                          self.allowed_values.day_of_week)
         next_dom, dom_overflow = self.__next_allowed_val(now_parts.day_of_month + (1 if hr_overflow else 0),
                                                          self.allowed_values.day_of_month)
-        if next_dom > monthrange(after.year, after.month)[1]:  # current month doesn't allow this month
+        if next_dom > monthrange(after.year, after.month)[1]:  # current month doesn't allow this day
             next_dom, dom_overflow = self.allowed_values.day_of_month[0], True
         next_day, day_overflow = self.__determine_day(after, next_dow, dow_overflow, next_dom, dom_overflow)
         if day_overflow or next_day > now_parts.day_of_month:  # backtrack

--- a/coc/ext/triggers/cron.py
+++ b/coc/ext/triggers/cron.py
@@ -1,0 +1,205 @@
+import warnings
+
+from calendar import monthrange
+from collections import namedtuple
+from datetime import datetime, timedelta
+from typing import Any, List, Tuple
+
+
+LIMITS = [[0, 59], [0, 23], [1, 31], [1, 12], [0, 6]]
+NAMES = ['minute', 'hour', 'day_of_month', 'month', 'day_of_week']
+CronParts = namedtuple('CronParts', NAMES)
+
+
+class CronParserError(Exception):
+    """Base exception for all errors during Cron string parsing"""
+
+    pass
+
+
+class CronSchedule:
+    """
+    A class representing a Cron schedule. It supports the full standard Cron dialect, but it does not
+    support name aliases for weekdays or months (e.g. Mon, Tue, ... and Jan, Feb, ...)
+
+    Attributes
+    ----------
+    cron_str: :class:`str`
+        the string representation of the Cron schedule
+    """
+
+    def __init__(self, cron_str: str):
+        try:
+            entries = CronParts(*cron_str.split())
+        except ValueError:
+            raise CronParserError(
+                'Invalid Cron string. A Cron string must consist of exactly five entries separated by '
+                'whitespaces: minute, hour, day of month, month, day of week. Example: `0 0 * * *`'
+            )
+
+        allowed_values = []
+        try:
+            for name, entry, limits in zip(NAMES, entries, LIMITS):
+                allowed_values.append(self.__parse_entry(name, entry, limits))
+        except ValueError:
+            raise CronParserError(
+                f'Invalid Cron string. {name.title()} is malformed. A Cron string element must either be the '
+                'wildcard `*` or contain one or more (comma-separated) entries. An entry must contain a time '
+                'indicator or a time range `start-end`, and it may contain an increment-suffix separated by a '
+                'slash `/`. Example: `4,12-18/2`'
+            )
+
+        self.cron_str = cron_str
+        self._entries = entries
+        self.allowed_values = CronParts(*allowed_values)
+
+    def __str__(self) -> str:
+        return self.cron_str
+
+    def __eq__(self, other: Any):
+        # two Cron schedules can be considered equal if they allow the same values
+        # i.e. Cron('0 0 * * *') == Cron('0 0 1-31 * *')
+        return self.__class__ == other.__class__ and self.allowed_values == other.allowed_values
+
+    @staticmethod
+    def __parse_entry(name: str, entry: str, limits: List[int]) -> List[int]:
+        """Parse a single entry of the cron string"""
+
+        allowed_values = []
+        for part in entry.split(','):
+            # split off increment
+            if '/' in part:
+                part, increment = part.split('/')
+                increment = int(increment)
+                if increment <= 0:
+                    raise CronParserError('Invalid Cron string. Increments must be > 0')
+            else:
+                increment = None
+
+            if part == '*':  # wildcard
+                start, end = limits[0], limits[1]
+            elif '-' in part:  # time range
+                start, end = part.split('-')
+                start, end = int(start), int(end)
+            else:  # single value
+                start = int(part)
+                end = limits[1] if increment else start
+
+            if start < limits[0] or end > limits[1]:
+                raise CronParserError(
+                    f'Invalid Cron string. {name.title()} is out of bounds: must be <= {limits[1]}, '
+                    f'>= {limits[0]}, got {start if start < limits[0] else end}'
+                )
+
+            if increment:
+                allowed_values.extend(list(range(start, end + 1, increment)))
+            else:
+                allowed_values.extend(list(range(start, end + 1)))
+        return sorted(allowed_values)
+
+    @staticmethod
+    def __next_allowed_val(value: int, allowed_values: List[int]) -> Tuple[int, bool]:
+        """Get the next allowed value from a list of choices and indicate if the list has overflown,
+        i.e. whether the next value needs to be incremented"""
+
+        for val in allowed_values:
+            if val >= value:
+                return val, False
+        return allowed_values[0], True
+
+    def __determine_day(self, reference_date: datetime, dow: int, dow_overflow: bool, dom: int, dom_overflow: bool):
+        """Solve the OR-relation between day of month and day of week, returning whichever is smaller"""
+
+        # translate day of week into its equivalent day of month
+        month_days = monthrange(reference_date.year, reference_date.month)[1]
+        dow = reference_date.day + (7 + dow - reference_date.isoweekday()) % 7 + \
+            (7 if dow_overflow and reference_date.isoweekday() == dow else 0)
+        dow_overflow = dow > month_days
+        dow = (dow - 1) % month_days + 1
+
+        # figure out which one is smaller
+        if self._entries.day_of_week != '*' and self._entries.day_of_month != '*':
+            if dow_overflow and not dom_overflow:
+                return dom, dom_overflow
+            elif dom_overflow and not dow_overflow:
+                return dow, dow_overflow
+            elif dom <= dow:
+                return dom, dom_overflow
+            else:
+                return dow, dow_overflow
+        elif self._entries.day_of_week != '*':
+            return dow, dow_overflow
+        else:
+            return dom, dom_overflow
+
+    def next_run_after(self, after: datetime) -> datetime:
+        """Calculate the next run time of the Cron schedule after a given reference datetime
+        Parameters
+        ----------
+        after: :class:`datetime.datetime`
+            the reference datetime
+
+        Returns
+        -------
+        The next run time after the reference datetime for the Cron schedule: :class:`datetime.datetime`.
+        If the input datetime was timezone-aware, the return will also be. If the input was timezone-naive,
+        so will the return be
+        """
+
+        # construct timezone-aware representation of after
+        tz_naive = not after.tzinfo
+        tz = datetime.now().astimezone().tzinfo
+        if tz_naive:
+            warnings.warn(
+                'The input datetime was datetime-naive. Assuming the time zone of your device for processing. '
+                'The return value will be datetime-naive again', category=RuntimeWarning
+            )
+            after = after.replace(tzinfo=tz)
+
+        now_parts = CronParts(after.minute, after.hour, after.day, after.month, after.isoweekday())
+
+        # next run's minute
+        next_minute, min_overflow = self.__next_allowed_val(now_parts.minute, self.allowed_values.minute)
+
+        # next run's hour
+        next_hour, hr_overflow = self.__next_allowed_val(now_parts.hour + (1 if min_overflow else 0),
+                                                         self.allowed_values.hour)
+        if hr_overflow or next_hour > now_parts.hour:  # we overflowed into the next hour, backtrack
+            next_minute = self.allowed_values.minute[0]
+
+        # next run's day
+        next_dow, dow_overflow = self.__next_allowed_val(now_parts.day_of_week + (1 if hr_overflow else 0),
+                                                         self.allowed_values.day_of_week)
+        next_dom, dom_overflow = self.__next_allowed_val(now_parts.day_of_month + (1 if hr_overflow else 0),
+                                                         self.allowed_values.day_of_month)
+        next_day, day_overflow = self.__determine_day(after, next_dow, dow_overflow, next_dom, dom_overflow)
+        if day_overflow or next_day > now_parts.day_of_month:  # backtrack
+            next_minute = self.allowed_values.minute[0]
+            next_hour = self.allowed_values.hour[0]
+
+        # next run's month & year
+        next_month, month_overflow = self.__next_allowed_val(now_parts.month + (1 if day_overflow else 0),
+                                                             self.allowed_values.month)
+        next_year = after.year + 1 if month_overflow else after.year
+        if month_overflow or next_month > now_parts.month:  # backtrack
+            next_minute = self.allowed_values.minute[0]
+            next_hour = self.allowed_values.hour[0]
+            next_dom = self.allowed_values.day_of_month[0]
+            next_dow = (monthrange(next_year, next_month)[0] + 1) % 7  # ISO weekday of the next month's first day
+            ref = (after.replace(day=1) + timedelta(days=32)).replace(day=1)
+            next_day, _ = self.__determine_day(ref, next_dow, dow_overflow, next_dom, dom_overflow)
+
+        if tz_naive:
+            return datetime(year=next_year, month=next_month, day=next_day, hour=next_hour, minute=next_minute)
+        return datetime(year=next_year, month=next_month, day=next_day, hour=next_hour, minute=next_minute, tzinfo=tz)
+
+    @property
+    def next_run(self) -> datetime:
+        """The next run time for this Cron schedule
+        Returns
+        -------
+        the next run time for this Cron schedule: :class:`datetime.datetime`
+        NOTE: the return value will always be timezone-AWARE
+        """
+
+        return self.next_run_after(datetime.now().astimezone())

--- a/coc/ext/triggers/cron.py
+++ b/coc/ext/triggers/cron.py
@@ -180,6 +180,8 @@ class CronSchedule:
                                                          self.allowed_values.day_of_week)
         next_dom, dom_overflow = self.__next_allowed_val(now_parts.day_of_month + (1 if hr_overflow else 0),
                                                          self.allowed_values.day_of_month)
+        if next_dom > monthrange(after.year, after.month)[1]:  # current month doesn't allow this month
+            next_dom, dom_overflow = self.allowed_values.day_of_month[0], True
         next_day, day_overflow = self.__determine_day(after, next_dow, dow_overflow, next_dom, dom_overflow)
         if day_overflow or next_day > now_parts.day_of_month:  # backtrack
             next_minute = self.allowed_values.minute[0]

--- a/coc/ext/triggers/triggers.py
+++ b/coc/ext/triggers/triggers.py
@@ -466,7 +466,25 @@ def on_error() -> Callable[[], ErrorHandler]:
 
 
 async def start_triggers():
-    """Manually start all triggers with `autostart=False`
+    """Manually start all triggers with `autostart=False` (which is the default value)
+
+    Example
+    --------
+    .. code-block:: python3
+
+        # define a trigger
+        @CronTrigger(cron_schedule='0 0 * * *', iter_args=['#2PP', '#2PPP'], autostart=False)
+        async def download_current_war(clan_tag: str):
+            # use your coc client to fetch war data, store it to a file or database, ...
+            pass
+
+        if __name__ = '__main__':
+            # login to coc.py and/or load other required resources here
+            event_loop = asyncio.get_event_loop()
+            # then start trigger execution
+            event_loop.run_until_complete(start_triggers())
+            # set the loop to run forever so that it keeps executing the triggers
+            event_loop.run_forever()
     """
 
     tasks = [asyncio.create_task(trigger) for trigger in trigger_registry]

--- a/coc/ext/triggers/triggers.py
+++ b/coc/ext/triggers/triggers.py
@@ -1,0 +1,115 @@
+import asyncio
+import functools
+
+from abc import ABC
+from datetime import datetime, timedelta
+from traceback import format_exception
+from typing import Any, Callable, Coroutine, Optional, Union
+
+
+# async def ... function type
+CoroFunction = Callable[[], Coroutine[Any, Any, Any]]
+
+
+class BaseTrigger(ABC):
+    """
+    Abstract base class for all repeating trigger decorators
+
+    Attributes
+    ----------
+    iter_args: Optional[:class:`list`]
+        an optional list of arguments. The decorated function will be called once per list element,
+        and the element will be passed to the decorated function as the first positional argument
+    on_startup: Optional[:class:`bool`]
+        whether to trigger a run of the decorated function on startup. Defaults to `True`
+    error_handler: Optional[:class:`coc.ext.triggers.CoroFunction`]
+        an optional function that will be called on each error incurred during the trigger execution
+    logger: Optional[:class:`logging.Logger`]
+        an optional logger instance implementing the logging.Logger functionality. Debug and error logs
+        about the trigger execution will be logged to this logger
+    loop: Optional[:class:`asyncio.AbstractEventLoop`]
+        an optional event loop that the trigger execution will be appended to. If no loop is provided,
+        the trigger will provision one using `asyncio.get_event_loop()`
+    kwargs:
+        any additional keyword arguments that will be passed to the decorated function every time it is called
+    """
+
+    def __init__(self,
+                 *,  # disable positional arguments
+                 iter_args: Optional[list] = None,
+                 on_startup: Optional[bool] = True,
+                 error_handler: Optional[CoroFunction] = None,
+                 logger: Optional[logging.Logger] = None,
+                 loop: Optional[asyncio.AbstractEventLoop] = None,
+                 **kwargs):
+
+        self.iter_args = iter_args
+        self.on_startup = on_startup
+        self.error_handler = error_handler
+        self.logger = logger
+        self.loop = loop or asyncio.get_event_loop()
+        self.kwargs = kwargs
+
+        self.current_execution: Union[datetime, None] = None
+        self.task = None  # placeholder for the repeat task created in self.__wrapper
+
+    def __call__(self, func: CoroFunction):
+        return self.__wrapper(func)
+
+    def __wrapper(self, func: CoroFunction):
+        """the main workhorse. Handles the repetition of the decorated function"""
+
+        # fill any passed kwargs
+        fixture = functools.partial(func, **self.kwargs)
+
+        @functools.wraps(fixture)
+        async def wrapped() -> None:
+            async def inner():
+                # maybe wait for next trigger cycle
+                if not self.on_startup:
+                    self.current_execution = datetime.now()
+                    await asyncio.sleep(self._get_sleep_time())
+
+                # repeat indefinitely
+                while True:
+                    self.current_execution = datetime.now()
+                    if self.logger:
+                        self.logger.debug(f'Running {self.__class__.__name__} for {func.__name__}')
+
+                    # call the decorated function
+                    try:
+                        if self.iter_args:
+                            await asyncio.gather(*map(fixture, self.iter_args))
+                        else:
+                            await fixture()
+                    except Exception as e:
+                        if self.logger:
+                            self.logger.error(''.join(format_exception(type(e), e, e.__traceback__)))
+                        # TODO: call error handler (and define proper args for it)
+
+                    # sleep until next execution time
+                    sleep_seconds = self._get_sleep_time()
+                    if self.logger and sleep_seconds > 0:
+                        next_run = datetime.now() + timedelta(seconds=sleep_seconds)
+                        self.logger.debug(
+                            f'{self.__class__.__name__} finished for {func.__name__}. Next run: {next_run.isoformat()}'
+                        )
+                    elif self.logger:  # i.e. sleep_seconds == 0
+                        self.logger.warning(
+                            f'{self.__class__.__name__} missed the scheduled run time for {func.__name__}. Running now'
+                        )
+
+                    await asyncio.sleep(sleep_seconds)
+
+            # create a reference to the repeating task to prevent it from accidentally being garbage collected
+            self.task = self.loop.create_task(inner())
+
+        if self.logger:
+            self.logger.debug(f'{self.__class__.__name__} set up for {func.__name__}')
+
+        return wrapped
+
+    def _get_sleep_time(self) -> float:
+        """calculate the time (in seconds) until the next scheduled run. Needs to be overwritten in subclasses"""
+        pass
+

--- a/coc/ext/triggers/triggers.py
+++ b/coc/ext/triggers/triggers.py
@@ -219,6 +219,24 @@ class IntervalTrigger(BaseTrigger):
 
         return datetime.now().astimezone() + timedelta(seconds=self._interval_seconds)
 
+    @classmethod
+    def hourly(cls, iter_args: Optional[list] = None, on_startup: bool = True,
+               error_handler: Optional[CoroFunction] = None, logger: Optional[logging.Logger] = None,
+               loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
+        """A shortcut to create a trigger that runs with a one-hour break between executions"""
+
+        return cls(seconds=3600, iter_args=iter_args, on_startup=on_startup,
+                   error_handler=error_handler, logger=logger, loop=loop, **kwargs)
+
+    @classmethod
+    def daily(cls, iter_args: Optional[list] = None, on_startup: bool = True,
+              error_handler: Optional[CoroFunction] = None, logger: Optional[logging.Logger] = None,
+              loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
+        """A shortcut to create a trigger that runs with a 24-hour break between executions"""
+
+        return cls(seconds=86400, iter_args=iter_args, on_startup=on_startup,
+                   error_handler=error_handler, logger=logger, loop=loop, **kwargs)
+
 
 class CronTrigger(BaseTrigger):
     """
@@ -277,6 +295,42 @@ class CronTrigger(BaseTrigger):
         # prevent multiple runs in one minute
         now = datetime.now().astimezone()
         return self.cron_schedule.next_run_after(now.replace(second=0, microsecond=0) + timedelta(minutes=1))
+
+    @classmethod
+    def hourly(cls, iter_args: Optional[list] = None, on_startup: bool = True,
+               error_handler: Optional[CoroFunction] = None, logger: Optional[logging.Logger] = None,
+               loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
+        """A shortcut to create a trigger that runs at the start of every hour"""
+
+        return cls(cron_schedule='0 * * * *', iter_args=iter_args, on_startup=on_startup,
+                   error_handler=error_handler, logger=logger, loop=loop, **kwargs)
+
+    @classmethod
+    def daily(cls, iter_args: Optional[list] = None, on_startup: bool = True,
+              error_handler: Optional[CoroFunction] = None, logger: Optional[logging.Logger] = None,
+              loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
+        """A shortcut to create a trigger that runs at the start of every day"""
+
+        return cls(cron_schedule='0 0 * * *', iter_args=iter_args, on_startup=on_startup,
+                   error_handler=error_handler, logger=logger, loop=loop, **kwargs)
+
+    @classmethod
+    def weekly(cls, iter_args: Optional[list] = None, on_startup: bool = True,
+               error_handler: Optional[CoroFunction] = None, logger: Optional[logging.Logger] = None,
+               loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
+        """A shortcut to create a trigger that runs at the start of every week (Sunday at 00:00)"""
+
+        return cls(cron_schedule='0 0 * * 0', iter_args=iter_args, on_startup=on_startup,
+                   error_handler=error_handler, logger=logger, loop=loop, **kwargs)
+
+    @classmethod
+    def monthly(cls, iter_args: Optional[list] = None, on_startup: bool = True,
+                error_handler: Optional[CoroFunction] = None, logger: Optional[logging.Logger] = None,
+                loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
+        """A shortcut to create a trigger that runs at the start of every month"""
+
+        return cls(cron_schedule='0 0 1 * *', iter_args=iter_args, on_startup=on_startup,
+                   error_handler=error_handler, logger=logger, loop=loop, **kwargs)
 
 
 def on_error() -> Callable[[], ErrorHandler]:

--- a/coc/ext/triggers/triggers.py
+++ b/coc/ext/triggers/triggers.py
@@ -26,26 +26,34 @@ class BaseTrigger(ABC):
 
     Attributes
     ----------
+
     iter_args: Optional[:class:`list`]
         an optional list of arguments. The decorated function will be called once per list element,
         and the element will be passed to the decorated function as the first positional argument
+
     on_startup: Optional[:class:`bool`]
         whether to trigger a run of the decorated function on startup. Defaults to `True`
+
     autostart: Optional[:class:`bool`]
         whether to automatically start the trigger. Auto-starting it may cause required components to not
         have fully loaded and initialized. If you choose to disable autostart (which is the default),
         you can use `coc.ext.triggers.start_triggers()` to manually kick the trigger execution off once you
         have loaded all required resources
+
     error_handler: Optional[:class:`coc.ext.triggers.CoroFunction`]
         an optional function that will be called on each error incurred during the trigger execution
+
     logger: Optional[:class:`logging.Logger`]
         an optional logger instance implementing the logging.Logger functionality. Debug and error logs
         about the trigger execution will be logged to this logger
+
     loop: Optional[:class:`asyncio.AbstractEventLoop`]
         an optional event loop that the trigger execution will be appended to. If no loop is provided,
         the trigger will provision one using `asyncio.get_event_loop()`
+
     kwargs:
         any additional keyword arguments that will be passed to the decorated function every time it is called
+
     """
 
     def __init__(self,
@@ -183,34 +191,42 @@ class IntervalTrigger(BaseTrigger):
 
     Attributes
     ----------
+
     seconds: :class:`int`
         how many seconds to wait between trigger runs
+
     iter_args: Optional[:class:`list`]
         an optional list of arguments. The decorated function will be called once per list element,
         and the element will be passed to the decorated function as the first positional argument. If
         no iter_args are defined, nothing (especially not `None`) will be injected into the decorated function
+
     on_startup: Optional[:class:`bool`]
         whether to trigger a run of the decorated function on startup. Defaults to `True`
+
     autostart: Optional[:class:`bool`]
         whether to automatically start the trigger. Auto-starting it may cause required components to not
         have fully loaded and initialized. If you choose to disable autostart (which is the default),
         you can use `coc.ext.triggers.start_triggers()` to manually kick the trigger execution off once you
         have loaded all required resources
+
     error_handler: Optional[:class:`coc.ext.triggers.CoroFunction`]
         an optional coroutine function that will be called on each error incurred during the trigger execution.
         The handler will receive three arguments:
-        function_name: :class:`str`
-            the name of the failing trigger's decorated function
-        arg: Optional[:class:`Any`]
-            the failing `iter_args` element or None if no iter_args are defined
-        exception: :class:`Exception`
-            the exception that occurred
+            function_name: :class:`str`
+                the name of the failing trigger's decorated function
+            arg: Optional[:class:`Any`]
+                the failing `iter_args` element or None if no iter_args are defined
+            exception: :class:`Exception`
+                the exception that occurred
+
     logger: Optional[:class:`logging.Logger`]
         an optional logger instance implementing the logging.Logger functionality. Debug, warning and error logs
         about the trigger execution will be sent to this logger
+
     loop: Optional[:class:`asyncio.AbstractEventLoop`]
         an optional event loop that the trigger execution will be appended to. If no loop is provided,
         the trigger will provision one using `asyncio.get_event_loop()`
+
     kwargs:
         any additional keyword arguments that will be passed to the decorated function every time it is called
 
@@ -222,6 +238,7 @@ class IntervalTrigger(BaseTrigger):
         async def download_current_war(clan_tag: str):
             # use your coc client to fetch war data, store it to a file or database, ...
             pass
+
     """
 
     def __init__(self,
@@ -283,43 +300,52 @@ class CronTrigger(BaseTrigger):
     ----------
     cron_schedule: Union[:class:`str`, :class:`coc.ext.triggers.CronSchedule`]
         the Cron schedule to follow
+
     iter_args: Optional[:class:`list`]
         an optional list of arguments. The decorated function will be called once per list element,
         and the element will be passed to the decorated function as the first positional argument. If
         no iter_args are defined, nothing (especially not `None`) will be injected into the decorated function
+
     on_startup: Optional[:class:`bool`]
         whether to trigger a run of the decorated function on startup. Defaults to `True`
+
     autostart: Optional[:class:`bool`]
         whether to automatically start the trigger. Auto-starting it may cause required components to not
         have fully loaded and initialized. If you choose to disable autostart (which is the default),
         you can use `coc.ext.triggers.start_triggers()` to manually kick the trigger execution off once you
         have loaded all required resources
+
     error_handler: Optional[:class:`coc.ext.triggers.CoroFunction`]
         an optional coroutine function that will be called on each error incurred during the trigger execution.
         The handler will receive three arguments:
-        function_name: :class:`str`
-            the name of the failing trigger's decorated function
-        arg: Optional[:class:`Any`]
-            the failing `iter_args` element or None if no iter_args are defined
-        exception: :class:`Exception`
-            the exception that occurred
+            function_name: :class:`str`
+                the name of the failing trigger's decorated function
+            arg: Optional[:class:`Any`]
+                the failing `iter_args` element or None if no iter_args are defined
+            exception: :class:`Exception`
+                the exception that occurred
+
     logger: Optional[:class:`logging.Logger`]
         an optional logger instance implementing the logging.Logger functionality. Debug, warning and error logs
         about the trigger execution will be sent to this logger
+
     loop: Optional[:class:`asyncio.AbstractEventLoop`]
         an optional event loop that the trigger execution will be appended to. If no loop is provided,
         the trigger will provision one using `asyncio.get_event_loop()`
+
     kwargs:
         any additional keyword arguments that will be passed to the decorated function every time it is called
 
+
     Example
-    -------
+    ----------
     .. code-block:: python3
 
         @CronTrigger(cron_schedule='0 0 * * *', iter_args=['#2PP', '#2PPP'])
         async def download_current_war(clan_tag: str):
             # use your coc client to fetch war data, store it to a file or database, ...
             pass
+
     """
 
     def __init__(self,
@@ -349,7 +375,8 @@ class CronTrigger(BaseTrigger):
 
         Returns
         -------
-        the next run date (timezone-aware): :class:`datetime.datetime`
+        :class:`datetime.datetime`
+            the next run date (timezone-aware):
         """
 
         # prevent multiple runs in one minute
@@ -401,13 +428,14 @@ def on_error() -> Callable[[], ErrorHandler]:
     -----
     This handler declaration should occur before any trigger declarations to avoid a RuntimeWarning about a
     potentially undeclared error handler, though that warning can safely be ignored.
+
     Any function decorated by this must be a coroutine and accept three parameters:
-    function_name: :class:`str`
-        the name of the failing trigger's decorated function
-    arg: Optional[:class:`Any`]
-        the failing `iter_args` element or None if no iter_args are defined
-    exception: :class:`Exception`
-        the exception that occurred
+        function_name: :class:`str`
+            the name of the failing trigger's decorated function
+        arg: Optional[:class:`Any`]
+            the failing `iter_args` element or None if no iter_args are defined
+        exception: :class:`Exception`
+            the exception that occurred
 
     Returns
     -------
@@ -421,6 +449,7 @@ def on_error() -> Callable[[], ErrorHandler]:
         async def handle_trigger_exception(function_name: str, arg: Any, exception: Exception):
             # send a Discord message, do some data cleanup, ...
             pass
+
     """
 
     def wrapper(func: ErrorHandler):

--- a/coc/ext/triggers/triggers.py
+++ b/coc/ext/triggers/triggers.py
@@ -432,6 +432,7 @@ def on_error() -> Callable[[], ErrorHandler]:
     potentially undeclared error handler, though that warning can safely be ignored.
 
     Any function decorated by this must be a coroutine and accept three parameters:
+
         function_name: :class:`str`
             the name of the failing trigger's decorated function
         arg: Optional[:class:`Any`]

--- a/coc/ext/triggers/triggers.py
+++ b/coc/ext/triggers/triggers.py
@@ -95,7 +95,7 @@ class BaseTrigger(ABC):
                 if not self.on_startup:
                     next_run = self.next_run
                     if self.logger:
-                        self.logger.debug(
+                        self.logger.info(
                             f'`on_startup` is set to `False`. First run of {self.__class__.__name__} for '
                             f'{func.__name__}: {next_run.isoformat()}'
                         )
@@ -104,7 +104,7 @@ class BaseTrigger(ABC):
                 # repeat indefinitely
                 while True:
                     if self.logger:
-                        self.logger.debug(f'Running {self.__class__.__name__} for {func.__name__}')
+                        self.logger.info(f'Running {self.__class__.__name__} for {func.__name__}')
 
                     # call the decorated function
                     try:
@@ -123,7 +123,7 @@ class BaseTrigger(ABC):
                     # sleep until next execution time
                     next_run = self.next_run
                     if self.logger and datetime.now().astimezone() <= next_run:
-                        self.logger.debug(
+                        self.logger.info(
                             f'{self.__class__.__name__} finished for {func.__name__}. Next run: {next_run.isoformat()}'
                         )
                     elif self.logger:  # i.e. next_run is in the past

--- a/coc/ext/triggers/triggers.py
+++ b/coc/ext/triggers/triggers.py
@@ -22,7 +22,8 @@ trigger_registry = []  # target for start_triggers()
 
 class BaseTrigger(ABC):
     """
-    Abstract base class for all repeating trigger decorators
+    Abstract base class for all repeating trigger decorators. This class can only be inherited from,
+    it cannot be instantiated. Any subclasses have to implement the :meth:`next_run` property
 
     Attributes
     ----------

--- a/coc/ext/triggers/triggers.py
+++ b/coc/ext/triggers/triggers.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import warnings
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from traceback import format_exception
 from typing import Any, Callable, Coroutine, Optional, Union
@@ -180,6 +180,7 @@ class BaseTrigger(ABC):
         await asyncio.sleep(max((wakeup_date - datetime.now().astimezone()).total_seconds(), 0))
 
     @property
+    @abstractmethod
     def next_run(self) -> datetime:
         """Calculate the date and time of the next run. Needs to be overwritten in subclasses"""
         raise NotImplementedError('All `BaseTrigger` subclasses need to implement `next_run`')

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -1,0 +1,88 @@
+.. py:currentmodule:: coc
+
+.. _triggers_extension:
+
+Triggers Extension
+=======================
+
+Overview
+--------
+
+coc.py's events are an extremely powerful framework, but they are not particularly well suited for periodic bulk-update style tasks, and employing the use of ``APScheduler`` or similar modules feels excessive for such a simple job. That is where the triggers extension for coc.py comes into play.
+
+This extension provides you with powerful and easy to use decorators that turn your coroutines into periodically repeating tasks without the need for any additional modifications. It is as simple as putting a trigger decorator on your existing coroutine functions. The triggers extension comes with:
+
+- two types of triggers: ``IntervalTrigger``  and ``CronTrigger``,
+- customisable error handlers for each trigger and a global ``@on_error()`` fallback handler,
+- extensive logging that can seamlessly be integrated with your existing logger,
+- integrated tools to apply your repeating function across an iterable.
+
+API Reference
+-------------
+
+IntervalTrigger
+~~~~~~~~~~~~~~~
+
+The ``IntervalTrigger`` will continuously loop the decorated function, sleeping for a defined number of seconds between executions. For convenience, this trigger defines ``.hourly()``  and ``.daily()`` class methods to instantiate triggers with a sleep time of 1 hour and 24 hours, respectively.
+
+.. autoclass:: coc.ext.triggers.IntervalTrigger
+   :members: hourly, daily
+
+CronTrigger
+~~~~~~~~~~~
+
+The ``CronTrigger`` allows you to specify a standard dialect Cron schedule string to dictate the trigger's executions. This allows you to specify highly specialised schedules to e.g. fetch clan game points before and after the clan games, legend league rankings before and after season reset and much more. For convenience, a set of class methods to instantiate triggers with common patters have been provided:
+
+- ``hourly()`` implements the "0 * * * *" schedule,
+- ``daily()`` implements "0 0 * * *",
+- ``weekly()`` implements "0 0 * * 0", and
+- ``monthly()`` implements "0 0 1 * *".
+
+.. autoclass:: coc.ext.triggers.CronTrigger
+   :members: hourly, daily, weekly, monthly
+
+Error Handling
+~~~~~~~~~~~~~~
+
+The triggers extension offers two ways to deal with error handling:
+
+- passing a handler function directly to the trigger's ``error_handler`` parameter. This allows you to specify individual error handlers for each repeated task if you need to.
+- designating a global error handler by decorating a function with ``coc.ext.triggers.on_error()``. This will be used as a fallback by all triggers that don't have a dedicated error handler passed to them during initialisation.
+
+.. autofunction:: coc.ext.triggers.on_error
+
+An error handler function must be defined with ``async def`` and accept three parameters in the following order:
+- a function_name string. The name of the failing trigger's decorated function will be passed to this parameter.
+- an arg of arbitrary type (defined by what is passed to the trigger's iter_args parameter). The failing element of the trigger's iter_args will be passed to this argument, if any are defined. Otherwise, this parameter will receive None.
+- an exception. This parameter will be passed the exception that occurred during the execution of the trigger.
+
+Additional arguments can statically be passed to the error handler making use of ``functools.partial``, if needed.
+
+Logging
+~~~~~~~
+
+Each trigger can be provided with a class implementing the ``logging.Logger`` functionality. If set, the logger will receive the following events:
+
+- **info**: trigger execution starts and finishes, along with the next scheduled run times.
+- **warning**: if a trigger missed it's next scheduled run time.
+- **error**: if an exception occurs during the execution of a trigger. If both a logger and an error handler are set up, both will receive information about this event.
+
+Other Parameters
+~~~~~~~~~~~~~~~~
+
+Similar to the events API, triggers allow you to specify a list of elements you want the decorated function to be spread over. If you specify the ``iter_args`` parameter when initialising a trigger, it will call the decorated function once for each element of that parameter. Each element will be positionally passed into the function's first argument. If you prefer to keep your logic inside the function or load it from somewhere else, simply don't pass the ``iter_args`` parameter. That will let the trigger know not to inject any positional args.
+You can also specify additional key word arguments (``**kwargs``). Any extra arguments will be passed to the decorated function on each call.
+The boolean ``on_startup`` flag allows you to control the trigger behaviour on startup. If it is set to ``True``, the trigger will fire immediately and resume its predefined schedule afterwards. If ``on_startup`` is ``False``, the trigger will remain dormant until its first scheduled run time.
+The ``autostart`` option allows you to decide whether a trigger should automatically start on application startup. If autostart is disabled, triggers can be started using ``coc.ext.triggers.start_triggers()`` once all dependencies and required resources are loaded.
+
+Example
+-------
+
+Below are some usage examples for the triggers extension:
+
+.. literalinclude:: ../../examples/triggers.py
+   :language: py
+   :linenos:
+
+
+---------------------------------------------

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -19,7 +19,8 @@ your existing coroutine functions. The triggers extension comes with:
 - two types of triggers: ``IntervalTrigger``  and ``CronTrigger``,
 - customisable error handlers for each trigger and a global ``@on_error()`` fallback handler,
 - extensive logging that can seamlessly be integrated with your existing logger,
-- integrated tools to apply your repeating function across an iterable.
+- integrated tools to apply your repeating function across an iterable, and
+- a framework that is easy to extend, allowing you to create your own custom triggers if you need to.
 
 API Reference
 -------------
@@ -138,5 +139,36 @@ Below are some usage examples for the triggers extension:
    :language: py
    :linenos:
 
+Extending this Extension
+------------------------
+
+If you find yourself in need of scheduling logic that none of the included triggers can provide, you can easily
+create a trigger class that fits your needs by importing the :class:`BaseTrigger` from this extension, creating a
+subclass and overwriting the ``next_run``  property. The property needs to return a *timezone-aware*
+``datetime.datetime`` object indicating when the trigger should run next based on the current system time.
 
 
+.. code-block:: python3
+    from coc.ext.triggers import BaseTrigger
+    from datetime import datetime, timedelta
+    from random import randint
+
+    class RandomTrigger(BaseTrigger):
+        def __init__(self,
+                     *,  # disable positional arguments
+                     seconds: int,
+                     iter_args: Optional[list] = None,
+                     on_startup: bool = True,
+                     autostart: bool = False,
+                     error_handler: Optional[CoroFunction] = None,
+                     logger: Optional[logging.Logger] = None,
+                     loop: Optional[asyncio.AbstractEventLoop] = None,
+                     **kwargs):
+
+            super().__init__(iter_args=iter_args, on_startup=on_startup, autostart=autostart,
+                             error_handler=error_handler, logger=logger, loop=loop, **kwargs)
+
+        @property
+        def next_run(self) -> datetime:
+            """randomly triggers every 50-100 seconds"""
+            return datetime.now().astimezone() + timedelta(seconds=random.randint(50, 101))

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -171,4 +171,4 @@ subclass and overwriting the ``next_run``  property. The property needs to retur
         @property
         def next_run(self) -> datetime:
             """randomly triggers every 50-100 seconds"""
-            return datetime.now().astimezone() + timedelta(seconds=random.randint(50, 101))
+            return datetime.now().astimezone() + timedelta(seconds=randint(50, 101))

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -149,26 +149,27 @@ subclass and overwriting the ``next_run``  property. The property needs to retur
 
 
 .. code-block:: python3
-    from coc.ext.triggers import BaseTrigger
-    from datetime import datetime, timedelta
-    from random import randint
 
-    class RandomTrigger(BaseTrigger):
-        def __init__(self,
-                     *,  # disable positional arguments
-                     seconds: int,
-                     iter_args: Optional[list] = None,
-                     on_startup: bool = True,
-                     autostart: bool = False,
-                     error_handler: Optional[CoroFunction] = None,
-                     logger: Optional[logging.Logger] = None,
-                     loop: Optional[asyncio.AbstractEventLoop] = None,
-                     **kwargs):
+   from coc.ext.triggers import BaseTrigger
+   from datetime import datetime, timedelta
+   from random import randint
 
-            super().__init__(iter_args=iter_args, on_startup=on_startup, autostart=autostart,
-                             error_handler=error_handler, logger=logger, loop=loop, **kwargs)
+   class RandomTrigger(BaseTrigger):
+       def __init__(self,
+                    *,  # disable positional arguments
+                    seconds: int,
+                    iter_args: Optional[list] = None,
+                    on_startup: bool = True,
+                    autostart: bool = False,
+                    error_handler: Optional[CoroFunction] = None,
+                    logger: Optional[logging.Logger] = None,
+                    loop: Optional[asyncio.AbstractEventLoop] = None,
+                    **kwargs):
 
-        @property
-        def next_run(self) -> datetime:
-            """randomly triggers every 50-100 seconds"""
-            return datetime.now().astimezone() + timedelta(seconds=randint(50, 101))
+           super().__init__(iter_args=iter_args, on_startup=on_startup, autostart=autostart,
+                            error_handler=error_handler, logger=logger, loop=loop, **kwargs)
+
+       @property
+       def next_run(self) -> datetime:
+           """randomly triggers every 50-100 seconds"""
+           return datetime.now().astimezone() + timedelta(seconds=randint(50, 101))

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -56,6 +56,7 @@ methods to instantiate triggers with common patters have been provided:
    :members: hourly, daily, weekly, monthly
 
 .. _Starting the Triggers:
+
 Starting the Triggers
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -54,6 +54,25 @@ methods to instantiate triggers with common patters have been provided:
 .. autoclass:: coc.ext.triggers.CronTrigger
    :members: hourly, daily, weekly, monthly
 
+.. _Starting the Triggers:
+Starting the Triggers
+~~~~~~~~~~~~~~~~~~~~~
+
+By default, triggers don't start on their own. This is because you typically want to load other resources before
+running a trigger, e.g. log in to the coc dev site, start your Discord bot or boot up a database connection. If a
+trigger fired right away, the initial runs would likely fail due to unavailability of these resources. Due to how
+Python works, a trigger would run the moment the interpreter reaches the definition, usually well before you intend
+to actually start (you can see that illustrated in the examples as well). That is why by default, all triggers are
+set to ``autostart=False``.
+
+The triggers extension provides a :meth:`coc.ext.triggers.start_triggers()` function to manually kick off trigger
+execution from within your code once you're ready to start processing. If you don't need any additional resources to
+load in first or have otherwise made sure that your triggers won't fire early, you can set them to ``autostart=True``
+and omit the call to :meth:`coc.ext.triggers.start_triggers()`. If you have a mixture of auto-started and not
+auto-started triggers, :meth:`coc.ext.triggers.start_triggers()` will only start the ones that aren't already running.
+
+.. autofunction:: coc.ext.triggers.start_triggers
+
 Error Handling
 ~~~~~~~~~~~~~~
 
@@ -95,16 +114,20 @@ spread over. If you specify the ``iter_args`` parameter when initialising a trig
 function once for each element of that parameter. Each element will be positionally passed into the function's first
 argument. If you prefer to keep your logic inside the function or load it from somewhere else, simply don't pass the
 ``iter_args`` parameter. That will let the trigger know not to inject any positional args.
-You can also specify additional key word arguments (``**kwargs``). Any extra arguments will be passed to the decorated
-function on each call.
+
 The boolean ``on_startup`` flag allows you to control the trigger behaviour on startup. If it is set to ``True``, the
 trigger will fire immediately and resume its predefined schedule afterwards. If ``on_startup`` is ``False``, the
 trigger will remain dormant until its first scheduled run time.
+
 The ``autostart`` option allows you to decide whether a trigger should automatically start on application startup.
 If autostart is disabled, triggers can be started using :meth:`coc.ext.triggers.start_triggers()` once all
-dependencies and required resources are loaded.
+dependencies and required resources are loaded. Refer to `Starting the Triggers`_ for details.
 
-.. autofunction:: coc.ext.triggers.start_triggers
+The ``loop`` parameter allows you to pass your own asyncio event loop to attach the trigger execution to. If omitted,
+the current event loop will be used.
+
+You can also specify additional key word arguments (``**kwargs``). Any extra arguments will be passed to the decorated
+function as key word arguments on each call.
 
 Example
 -------

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -23,7 +23,7 @@ API Reference
 IntervalTrigger
 ~~~~~~~~~~~~~~~
 
-The ``IntervalTrigger`` will continuously loop the decorated function, sleeping for a defined number of seconds between executions. For convenience, this trigger defines ``.hourly()``  and ``.daily()`` class methods to instantiate triggers with a sleep time of 1 hour and 24 hours, respectively.
+The :class:`IntervalTrigger` will continuously loop the decorated function, sleeping for a defined number of seconds between executions. For convenience, this trigger defines ``.hourly()``  and ``.daily()`` class methods to instantiate triggers with a sleep time of 1 hour and 24 hours, respectively.
 
 .. autoclass:: coc.ext.triggers.IntervalTrigger
    :members: hourly, daily
@@ -31,7 +31,7 @@ The ``IntervalTrigger`` will continuously loop the decorated function, sleeping 
 CronTrigger
 ~~~~~~~~~~~
 
-The ``CronTrigger`` allows you to specify a standard dialect Cron schedule string to dictate the trigger's executions. This allows you to specify highly specialised schedules to e.g. fetch clan game points before and after the clan games, legend league rankings before and after season reset and much more. For convenience, a set of class methods to instantiate triggers with common patters have been provided:
+The :class:`CronTrigger` allows you to specify a standard dialect Cron schedule string to dictate the trigger's executions. This allows you to specify highly specialised schedules to e.g. fetch clan game points before and after the clan games, legend league rankings before and after season reset and much more. For convenience, a set of class methods to instantiate triggers with common patters have been provided:
 
 - ``hourly()`` implements the ``0 * * * *`` schedule,
 
@@ -77,7 +77,9 @@ Other Parameters
 Similar to the events API, triggers allow you to specify a list of elements you want the decorated function to be spread over. If you specify the ``iter_args`` parameter when initialising a trigger, it will call the decorated function once for each element of that parameter. Each element will be positionally passed into the function's first argument. If you prefer to keep your logic inside the function or load it from somewhere else, simply don't pass the ``iter_args`` parameter. That will let the trigger know not to inject any positional args.
 You can also specify additional key word arguments (``**kwargs``). Any extra arguments will be passed to the decorated function on each call.
 The boolean ``on_startup`` flag allows you to control the trigger behaviour on startup. If it is set to ``True``, the trigger will fire immediately and resume its predefined schedule afterwards. If ``on_startup`` is ``False``, the trigger will remain dormant until its first scheduled run time.
-The ``autostart`` option allows you to decide whether a trigger should automatically start on application startup. If autostart is disabled, triggers can be started using ``coc.ext.triggers.start_triggers()`` once all dependencies and required resources are loaded.
+The ``autostart`` option allows you to decide whether a trigger should automatically start on application startup. If autostart is disabled, triggers can be started using :meth:`coc.ext.triggers.start_triggers()` once all dependencies and required resources are loaded.
+
+.. autofunction:: coc.ext.triggers.start_triggers
 
 Example
 -------

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -8,9 +8,13 @@ Triggers Extension
 Overview
 --------
 
-coc.py's events are an extremely powerful framework, but they are not particularly well suited for periodic bulk-update style tasks, and employing the use of ``APScheduler`` or similar modules feels excessive for such a simple job. That is where the triggers extension for coc.py comes into play.
+coc.py's events are an extremely powerful framework, but they are not particularly well suited for periodic bulk-update
+style tasks, and employing the use of ``APScheduler`` or similar modules feels excessive for such a simple job. That is
+where the triggers extension for coc.py comes into play.
 
-This extension provides you with powerful and easy to use decorators that turn your coroutines into periodically repeating tasks without the need for any additional modifications. It is as simple as putting a trigger decorator on your existing coroutine functions. The triggers extension comes with:
+This extension provides you with powerful and easy to use decorators that turn your coroutines into periodically
+repeating tasks without the need for any additional modifications. It is as simple as putting a trigger decorator on
+your existing coroutine functions. The triggers extension comes with:
 
 - two types of triggers: ``IntervalTrigger``  and ``CronTrigger``,
 - customisable error handlers for each trigger and a global ``@on_error()`` fallback handler,
@@ -23,7 +27,9 @@ API Reference
 IntervalTrigger
 ~~~~~~~~~~~~~~~
 
-The :class:`IntervalTrigger` will continuously loop the decorated function, sleeping for a defined number of seconds between executions. For convenience, this trigger defines ``.hourly()``  and ``.daily()`` class methods to instantiate triggers with a sleep time of 1 hour and 24 hours, respectively.
+The :class:`IntervalTrigger` will continuously loop the decorated function, sleeping for a defined number of seconds
+between executions. For convenience, this trigger defines ``.hourly()``  and ``.daily()`` class methods to instantiate
+triggers with a sleep time of 1 hour and 24 hours, respectively.
 
 .. autoclass:: coc.ext.triggers.IntervalTrigger
    :members: hourly, daily
@@ -31,7 +37,10 @@ The :class:`IntervalTrigger` will continuously loop the decorated function, slee
 CronTrigger
 ~~~~~~~~~~~
 
-The :class:`CronTrigger` allows you to specify a standard dialect Cron schedule string to dictate the trigger's executions. This allows you to specify highly specialised schedules to e.g. fetch clan game points before and after the clan games, legend league rankings before and after season reset and much more. For convenience, a set of class methods to instantiate triggers with common patters have been provided:
+The :class:`CronTrigger` allows you to specify a standard dialect Cron schedule string to dictate the trigger's
+executions. This allows you to specify highly specialised schedules to e.g. fetch clan game points before and after
+the clan games, legend league rankings before and after season reset and much more. For convenience, a set of class
+methods to instantiate triggers with common patters have been provided:
 
 - ``hourly()`` implements the ``0 * * * *`` schedule,
 
@@ -50,14 +59,19 @@ Error Handling
 
 The triggers extension offers two ways to deal with error handling:
 
-- passing a handler function directly to the trigger's ``error_handler`` parameter. This allows you to specify individual error handlers for each repeated task if you need to.
-- designating a global error handler by decorating a function with ``coc.ext.triggers.on_error()``. This will be used as a fallback by all triggers that don't have a dedicated error handler passed to them during initialisation.
+- passing a handler function directly to the trigger's ``error_handler`` parameter. This allows you to specify
+  individual error handlers for each repeated task if you need to.
+- designating a global error handler by decorating a function with ``coc.ext.triggers.on_error()``. This will be used
+  as a fallback by all triggers that don't have a dedicated error handler passed to them during initialisation.
 
 .. autofunction:: coc.ext.triggers.on_error
 
 An error handler function must be defined with ``async def`` and accept three parameters in the following order:
+
 - a function_name string. The name of the failing trigger's decorated function will be passed to this parameter.
-- an arg of arbitrary type (defined by what is passed to the trigger's iter_args parameter). The failing element of the trigger's iter_args will be passed to this argument, if any are defined. Otherwise, this parameter will receive None.
+- an arg of arbitrary type (defined by what is passed to the trigger's iter_args parameter). The failing element of
+  the trigger's iter_args will be passed to this argument, if any are defined. Otherwise, this parameter will receive
+  ``None``.
 - an exception. This parameter will be passed the exception that occurred during the execution of the trigger.
 
 Additional arguments can statically be passed to the error handler making use of ``functools.partial``, if needed.
@@ -65,19 +79,30 @@ Additional arguments can statically be passed to the error handler making use of
 Logging
 ~~~~~~~
 
-Each trigger can be provided with a class implementing the ``logging.Logger`` functionality. If set, the logger will receive the following events:
+Each trigger can be provided with a class implementing the ``logging.Logger`` functionality. If set, the logger will
+receive the following events:
 
 - **info**: trigger execution starts and finishes, along with the next scheduled run times.
 - **warning**: if a trigger missed it's next scheduled run time.
-- **error**: if an exception occurs during the execution of a trigger. If both a logger and an error handler are set up, both will receive information about this event.
+- **error**: if an exception occurs during the execution of a trigger. If both a logger and an error handler are set
+  up, both will receive information about this event.
 
 Other Parameters
 ~~~~~~~~~~~~~~~~
 
-Similar to the events API, triggers allow you to specify a list of elements you want the decorated function to be spread over. If you specify the ``iter_args`` parameter when initialising a trigger, it will call the decorated function once for each element of that parameter. Each element will be positionally passed into the function's first argument. If you prefer to keep your logic inside the function or load it from somewhere else, simply don't pass the ``iter_args`` parameter. That will let the trigger know not to inject any positional args.
-You can also specify additional key word arguments (``**kwargs``). Any extra arguments will be passed to the decorated function on each call.
-The boolean ``on_startup`` flag allows you to control the trigger behaviour on startup. If it is set to ``True``, the trigger will fire immediately and resume its predefined schedule afterwards. If ``on_startup`` is ``False``, the trigger will remain dormant until its first scheduled run time.
-The ``autostart`` option allows you to decide whether a trigger should automatically start on application startup. If autostart is disabled, triggers can be started using :meth:`coc.ext.triggers.start_triggers()` once all dependencies and required resources are loaded.
+Similar to the events API, triggers allow you to specify a list of elements you want the decorated function to be
+spread over. If you specify the ``iter_args`` parameter when initialising a trigger, it will call the decorated
+function once for each element of that parameter. Each element will be positionally passed into the function's first
+argument. If you prefer to keep your logic inside the function or load it from somewhere else, simply don't pass the
+``iter_args`` parameter. That will let the trigger know not to inject any positional args.
+You can also specify additional key word arguments (``**kwargs``). Any extra arguments will be passed to the decorated
+function on each call.
+The boolean ``on_startup`` flag allows you to control the trigger behaviour on startup. If it is set to ``True``, the
+trigger will fire immediately and resume its predefined schedule afterwards. If ``on_startup`` is ``False``, the
+trigger will remain dormant until its first scheduled run time.
+The ``autostart`` option allows you to decide whether a trigger should automatically start on application startup.
+If autostart is disabled, triggers can be started using :meth:`coc.ext.triggers.start_triggers()` once all
+dependencies and required resources are loaded.
 
 .. autofunction:: coc.ext.triggers.start_triggers
 

--- a/docs/extensions/triggers.rst
+++ b/docs/extensions/triggers.rst
@@ -33,10 +33,14 @@ CronTrigger
 
 The ``CronTrigger`` allows you to specify a standard dialect Cron schedule string to dictate the trigger's executions. This allows you to specify highly specialised schedules to e.g. fetch clan game points before and after the clan games, legend league rankings before and after season reset and much more. For convenience, a set of class methods to instantiate triggers with common patters have been provided:
 
-- ``hourly()`` implements the "0 * * * *" schedule,
-- ``daily()`` implements "0 0 * * *",
-- ``weekly()`` implements "0 0 * * 0", and
-- ``monthly()`` implements "0 0 1 * *".
+- ``hourly()`` implements the ``0 * * * *`` schedule,
+
+- ``daily()`` implements ``0 0 * * *``,
+
+- ``weekly()`` implements ``0 0 * * 0``, and
+
+- ``monthly()`` implements ``0 0 1 * *``.
+
 
 .. autoclass:: coc.ext.triggers.CronTrigger
    :members: hourly, daily, weekly, monthly
@@ -85,4 +89,4 @@ Below are some usage examples for the triggers extension:
    :linenos:
 
 
----------------------------------------------
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ coc.py: A Clash of Clans API Wrapper
 
    extensions/discord_links
    extensions/full_war_api
+   extensions/triggers
 
 .. _examples:
 .. toctree::

--- a/examples/triggers.py
+++ b/examples/triggers.py
@@ -75,9 +75,19 @@ if __name__ == "__main__":
     try:
         # using the loop context, run the main function
         event_loop.run_until_complete(main())
+
+        # wait a few seconds to simulate other resources loading
+        event_loop.run_until_complete(asyncio.sleep(3))
+
+        # note how this print statement will show up in your console AFTER the auto-started trigger fired
+        print('NOTE: Auto-started trigger "test_default_error_handling" has already fired at this point')
+
         # then start trigger execution
         event_loop.run_until_complete(start_triggers())
+
         # set the loop to run forever so that it keeps executing the triggers
+        # NOTE: this line is blocking, no code after will be executed
         event_loop.run_forever()
+        print('This line will never make it to your console')
     except KeyboardInterrupt:
         pass

--- a/examples/triggers.py
+++ b/examples/triggers.py
@@ -1,0 +1,83 @@
+import asyncio
+import logging
+import os
+
+import coc
+from coc.ext.triggers import CronSchedule, CronTrigger, IntervalTrigger, on_error, start_triggers
+
+
+coc_client = coc.Client()
+cron = CronSchedule('0 0 * * *')
+event_loop = asyncio.get_event_loop()
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S')
+_logger = logging.getLogger()
+MOCK_DATABASE = {'cg_contribution': {}, 'donations': {}}
+
+
+@on_error()
+async def default_error_handler(function_name, arg, exception):
+    print('Default error handler engaged')
+    print('Default handler:', function_name, arg, exception)
+
+
+async def special_error_handler(function_name, arg, exception):
+    print('Special error handler engaged')
+    print('Special handler:', function_name, arg, exception)
+
+
+@CronTrigger(cron_schedule='0 0 * * 5', iter_args=['#2PP', '#2PPP'], on_startup=False, loop=event_loop, logger=_logger)
+async def cache_cg_contribution_before_raid_weekend(player_tag: str):
+    """This trigger showcases the `on_startup=False` option and the use of `iter_args`"""
+
+    player = await coc_client.get_player(player_tag)
+    MOCK_DATABASE['cg_contribution'][player.tag] = player.clan_capital_contributions
+
+    print('capital gold contributions', MOCK_DATABASE['cg_contribution'])
+
+
+@CronTrigger(cron_schedule=cron, iter_args=['#2PP'], loop=event_loop, logger=_logger)
+async def daily_donation_downloader(clan_tag: str):
+    """This trigger showcases the use of a :class:`CronSchedule` object and `iter_args`"""
+
+    clan = await coc_client.get_clan(clan_tag)
+    async for member in clan.get_detailed_members():
+        MOCK_DATABASE['donations'][member.tag] = member.donations
+
+    print('donation status', MOCK_DATABASE['donations'])
+
+
+@IntervalTrigger.hourly(loop=event_loop, logger=_logger, error_handler=special_error_handler)
+async def test_special_error_handling():
+    """This trigger showcases the convenience class methods and the use of a dedicated error handler"""
+
+    return 1/0
+
+
+@IntervalTrigger(seconds=10, iter_args=[1, 0], autostart=True, loop=event_loop, logger=_logger)
+async def test_default_error_handling(divisor: int):
+    """This trigger demonstrates the use of `autostart=True` (this is fine because it has no dependencies
+    on other resources) in combination with `iter_args` and the default error handler defined by @on_error.
+    It also is the trigger with the lowest repeat timer to showcase the fact that triggers indeed do repeat
+    """
+
+    return 2/divisor
+
+
+async def main():
+    try:
+        await coc_client.login(os.environ.get('DEV_SITE_EMAIL'), os.environ.get('DEV_SITE_PASSWORD'))
+    except coc.InvalidCredentials as error:
+        exit(error)
+
+
+if __name__ == "__main__":
+    try:
+        # using the loop context, run the main function
+        event_loop.run_until_complete(main())
+        # then start trigger execution
+        event_loop.run_until_complete(start_triggers())
+        # set the loop to run forever so that it keeps executing the triggers
+        event_loop.run_forever()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
This PR adds `coc.ext.triggers` with decorators to turn coroutines into automatically repeated tasks based on either CRON schedules or timed intervals