### PR TITLE
Improve __eq__ functions in raid classes

### DIFF
--- a/coc/entry_logs.py
+++ b/coc/entry_logs.py
@@ -44,7 +44,7 @@ class LogPaginator(ABC):
         if self._sync_index == len(self._init_logs):
             raise StopIteration
         ret = self._model(data=self._init_logs[self._sync_index],
-                          client=self._client, response_retry=self._response_retry)
+                          client=self._client, response_retry=self._response_retry, clan_tag=self._clan_tag)
         self._sync_index += 1
         return ret
 
@@ -52,8 +52,8 @@ class LogPaginator(ABC):
         """Support indexing the object. This will not fetch any addition
         items from the endpoint"""
         try:
-            ret = self._init_logs[index]
-            return self._model(data=ret, client=self._client, response_retry=self._response_retry)
+            return self._model(data=self._init_logs[index],
+                               client=self._client, response_retry=self._response_retry, clan_tag=self._clan_tag)
         except Exception:
             raise
 
@@ -92,7 +92,7 @@ class LogPaginator(ABC):
             if self._async_index == len(self._logs):
                 raise StopAsyncIteration
             ret = self._model(data=self._logs[self._async_index],
-                              client=self._client, response_retry=self._response_retry)
+                              client=self._client, response_retry=self._response_retry, clan_tag=self._clan_tag)
             self._async_index += 1
             return ret
 
@@ -115,7 +115,7 @@ class LogPaginator(ABC):
             raise StopAsyncIteration
 
         self._async_index += 1
-        return self._model(data=ret, client=self._client, response_retry=self._response_retry)
+        return self._model(data=ret, client=self._client, response_retry=self._response_retry, clan_tag=self._clan_tag)
 
     async def _paginate(self) -> None:
         """

--- a/coc/raid.py
+++ b/coc/raid.py
@@ -159,7 +159,8 @@ class RaidAttack:
                 and self.attacker_tag == other.attacker_tag
                 and self.destruction == other.destruction
                 and self.raid_clan == other.raid_clan
-                and self.district == other.district)
+                and self.district == other.district
+                and self.stars == other.stars)
 
     def __init__(self, data, client, raid_log_entry, raid_clan, district):
         self.raid_log_entry = raid_log_entry

--- a/coc/raid.py
+++ b/coc/raid.py
@@ -161,15 +161,11 @@ class RaidAttack:
         return "<%s %s>" % (self.__class__.__name__, " ".join("%s=%r" % t for t in attrs),)
 
     def __eq__(self, other):
-        if isinstance(other, RaidAttack):
-            if (self.attacker_tag == other.attacker_tag
+        return (isinstance(other, RaidAttack)
+                and self.attacker_tag == other.attacker_tag
                 and self.destruction == other.destruction
-                and self.stars == other.stars
                 and self.raid_clan == other.raid_clan
-                and self.district == other.district
-            ):
-                return True
-        return False
+                and self.district == other.district)
 
     def __init__(self, data, client, raid_log_entry, raid_clan, district):
         self.raid_log_entry = raid_log_entry
@@ -216,17 +212,9 @@ class RaidDistrict:
     """
 
     def __eq__(self, other):
-        if isinstance(other, RaidDistrict):
-            if (self.id == other.id
-                and self.name == other.name
-                and self.hall_level == other.hall_level
-                and self.destruction == other.destruction
-                and self.looted == other.looted
-                and self.raid_clan == other.raid_clan
-                and self.attack_count == other.attack_count
-            ):
-                return True
-        return False
+        return (isinstance(other, RaidDistrict)
+                and self.id == other.id
+                and self.raid_clan == other.raid_clan)
 
     __slots__ = ("id",
                  "name",
@@ -333,9 +321,6 @@ class RaidClan:
     def __eq__(self, other):
         return (isinstance(other, RaidClan)
                 and self.tag == other.tag
-                and self.attack_count == other.attack_count
-                and self.district_count == other.district_count
-                and self.destroyed_district_count == other.destroyed_district_count
                 and self.raid_log_entry.start_time == other.raid_log_entry.start_time
                 and self.index == other.index)
 

--- a/coc/raid.py
+++ b/coc/raid.py
@@ -80,15 +80,9 @@ class RaidMember(BasePlayer):
         return "<%s %s>" % (self.__class__.__name__, " ".join("%s=%r" % t for t in attrs),)
 
     def __eq__(self, other):
-        if isinstance(other, RaidMember):
-            if (self.tag == other.tag
-                    and self.attack_count == other.attack_count
-                    and self.attack_limit == other.attack_limit
-                    and self.bonus_attack_limit == other.bonus_attack_limit
-                    and self.capital_resources_looted == other.capital_resources_looted
-            ):
-                return True
-        return False
+        return (isinstance(other, RaidMember)
+                and self.tag == other.tag
+                and self.raid_log_entry == other.raid_log_entry)
 
     def _from_data(self, data):
         data_get = data.get
@@ -389,7 +383,8 @@ class RaidLogEntry:
         :class:`int`: The amount of defensive reward
     """
 
-    __slots__ = ("state",
+    __slots__ = ("clan_tag",
+                 "state",
                  "start_time",
                  "end_time",
                  "total_loot",
@@ -414,6 +409,7 @@ class RaidLogEntry:
 
     def __init__(self, *, data, client, **kwargs):
         self._client = client
+        self.clan_tag = kwargs['clan_tag'] if "clan_tag" in kwargs else ""
         self._response_retry = kwargs['response_retry'] if "response_retry" in kwargs else 0
         self._raw_data = data if client and client.raw_attribute else None
         self._from_data(data)
@@ -429,17 +425,9 @@ class RaidLogEntry:
         return "<%s %s>" % (self.__class__.__name__, " ".join("%s=%r" % t for t in attrs),)
 
     def __eq__(self, other):
-        if isinstance(other, RaidLogEntry):
-            if (self.start_time == other.start_time
-                    and self.completed_raid_count == other.completed_raid_count
-                    and self.destroyed_district_count == other.destroyed_district_count
-                    and self.attack_count == other.attack_count
-                    and self.attack_log == other.attack_log
-                    and self.defense_log == other.defense_log
-            ):
-                return True
-
-        return False
+        return (isinstance(other, RaidLogEntry)
+                and self.start_time == other.start_time
+                and self.clan_tag == other.clan_tag)
 
 
     def _from_data(self, data: dict) -> None:


### PR DESCRIPTION
The old `RaidClan.__eq__` only returned true if the attacks on it where identical. Because the `__eq__` functions of `RaidDistrict` and `RaidAttack` checked if their parent `RaidClan` was identical, **all** the attacks and districts said they were different as soon as one additional attack on any district was made. I say this is a bug because only that district/attack changed and the others should have their `__eq__` return true when compared with the same attack/district from before. This is what this PR fixes. Additionally, I improved the code style and removed some redundant checks.