### PR TITLE
Rename first parameter of various classes hero/spell/troop

### DIFF
--- a/coc/hero.py
+++ b/coc/hero.py
@@ -171,13 +171,13 @@ class Pet(DataContainer):
     is_loaded: bool = False
     required_th_level: int
 
-    def __repr__(cls):
+    def __repr__(self):
         attrs = [
-            ("name", cls.name),
-            ("id", cls.id),
+            ("name", self.name),
+            ("id", self.id),
         ]
         return "<%s %s>" % (
-            cls.__name__, " ".join("%s=%r" % t for t in attrs),)
+            self.__class__.__name__, " ".join("%s=%r" % t for t in attrs),)
 
     @property
     def is_max_for_townhall(self) -> bool:

--- a/coc/hero.py
+++ b/coc/hero.py
@@ -75,13 +75,13 @@ class Hero(DataContainer):
     regeneration_time: "TimeDelta"
     is_loaded: bool = False
 
-    def __repr__(cls):
+    def __repr__(self):
         attrs = [
-            ("name", cls.name),
-            ("id", cls.id),
+            ("name", self.name),
+            ("id", self.id),
         ]
         return "<%s %s>" % (
-            cls.__name__, " ".join("%s=%r" % t for t in attrs),)
+            self.__class__.__name__, " ".join("%s=%r" % t for t in attrs),)
 
     @property
     def is_max_for_townhall(self) -> bool:

--- a/coc/spell.py
+++ b/coc/spell.py
@@ -5,7 +5,6 @@ from .abc import DataContainer, DataContainerHolder
 from .enums import Resource
 from .miscmodels import TimeDelta
 
-
 SPELLS_FILE_PATH = Path(__file__).parent.joinpath(Path("static/spells.json"))
 
 
@@ -67,13 +66,13 @@ class Spell(DataContainer):
     is_dark_spell: bool = False
     is_loaded: bool = False
 
-    def __repr__(cls):
+    def __repr__(self):
         attrs = [
-            ("name", cls.name),
-            ("id", cls.id),
+            ("name", self.name),
+            ("id", self.id),
         ]
         return "<%s %s>" % (
-            cls.__name__, " ".join("%s=%r" % t for t in attrs),)
+            self.__class__.__name__, " ".join("%s=%r" % t for t in attrs),)
 
     @property
     def is_max_for_townhall(self):
@@ -90,7 +89,7 @@ class Spell(DataContainer):
         #    and for troop level above, it requires a higher TH than we currently have.
         #    Maybe there's a better way to go about doing this.
         return self.lab_to_townhall[self.__class__.lab_level[self.level]] <= self._townhall \
-                    < self.lab_to_townhall[self.__class__.lab_level[self.level + 1]]
+             < self.lab_to_townhall[self.__class__.lab_level[self.level + 1]]
 
     @classmethod
     def get_max_level_for_townhall(cls, townhall):

--- a/coc/troop.py
+++ b/coc/troop.py
@@ -108,7 +108,7 @@ class Troop(DataContainer):
             ("id", cls.id),
         ]
         return "<%s %s>" % (
-            cls.__name__, " ".join("%s=%r" % t for t in attrs),)
+            cls.name, " ".join("%s=%r" % t for t in attrs),)
 
 
     @classmethod

--- a/coc/troop.py
+++ b/coc/troop.py
@@ -8,7 +8,6 @@ from .enums import Resource
 from .miscmodels import TimeDelta, try_enum
 from .utils import UnitStat
 
-
 TROOPS_FILE_PATH = Path(__file__).parent.joinpath(Path("static/characters.json"))
 SUPER_TROOPS_FILE_PATH = Path(__file__).parent.joinpath(Path("static/supers.json"))
 
@@ -102,14 +101,13 @@ class Troop(DataContainer):
     is_super_troop: bool = False
     is_loaded: bool = False
 
-    def __repr__(cls):
+    def __repr__(self):
         attrs = [
-            ("name", cls.name),
-            ("id", cls.id),
+            ("name", self.name),
+            ("id", self.id),
         ]
         return "<%s %s>" % (
-            cls.name, " ".join("%s=%r" % t for t in attrs),)
-
+            self.__class__.__name__, " ".join("%s=%r" % t for t in attrs),)
 
     @classmethod
     def _inject_super_meta(cls, troop_meta):
@@ -137,7 +135,7 @@ class Troop(DataContainer):
         #    and for troop level above, it requires a higher TH than we currently have.
         #    Maybe there's a better way to go about doing this.
         return self.lab_to_townhall[self.__class__.lab_level[self.level]] <= self._townhall \
-                    < self.lab_to_townhall[self.__class__.lab_level[self.level + 1]]
+             < self.lab_to_townhall[self.__class__.lab_level[self.level + 1]]
 
     @classmethod
     def get_max_level_for_townhall(cls, townhall):
@@ -223,4 +221,3 @@ class TroopHolder(DataContainerHolder):
             return self.item_lookup[(name, home_village)]
         except KeyError:
             return None
-


### PR DESCRIPTION
this was breaking, iirc particularly for pets. Changed to the above & works flawless now