### PR TITLE
fix generator return typing + add clan_tag to war class

### DIFF
--- a/coc/ext/fullwarapi/__init__.py
+++ b/coc/ext/fullwarapi/__init__.py
@@ -189,7 +189,8 @@ class FullWarClient:
                                    f"/war_result_log?clan_tag={correct_tag(clan_tag, '%23')}")
         try:
             responses = data["log"]
-            return (ClanWar(data=response["response"], client=self.coc_client, clan_tag=coc.utils.correct_tag(clan_tag)) for response in responses)
+            return (ClanWar(data=response["response"], client=self.coc_client,
+                            clan_tag=coc.utils.correct_tag(clan_tag)) for response in responses)
         except (IndexError, KeyError, TypeError, ValueError):
             return None
 

--- a/coc/ext/fullwarapi/__init__.py
+++ b/coc/ext/fullwarapi/__init__.py
@@ -168,11 +168,11 @@ class FullWarClient:
                                    f"/war_result?clan_tag={correct_tag(clan_tag, '%23')}"
                                    f"&prep_start={str(preparation_start)}")
         try:
-            return ClanWar(data=data["response"], client=self.coc_client)
+            return ClanWar(data=data["response"], client=self.coc_client, clan_tag=coc.utils.correct_tag(clan_tag))
         except (IndexError, KeyError, TypeError, ValueError):
             return None
 
-    async def war_result_log(self, clan_tag: str) -> Optional[Generator[ClanWar]]:
+    async def war_result_log(self, clan_tag: str) -> Optional[Generator[ClanWar, None, None]]:
         """Get all stored war results for a clan.
 
         Parameters
@@ -189,9 +189,7 @@ class FullWarClient:
                                    f"/war_result_log?clan_tag={correct_tag(clan_tag, '%23')}")
         try:
             responses = data["log"]
-
-            generator = (ClanWar(data=response["response"], client=self.coc_client) for response in responses)
-            return generator
+            return (ClanWar(data=response["response"], client=self.coc_client, clan_tag=coc.utils.correct_tag(clan_tag)) for response in responses)
         except (IndexError, KeyError, TypeError, ValueError):
             return None
 


### PR DESCRIPTION
would break on runtime, when trying to use the fw api, but generator typing fixed - needed 3 parameters & only had 1. also added clan_tag to war_class, because the response doesn't specify clan & opponent, so the class needs the tag to do so