### PR TITLE
Fix for get_current_war

### DIFF
--- a/coc/client.py
+++ b/coc/client.py
@@ -1136,9 +1136,8 @@ class Client:
 
         if league_group.state == "notInWar" or league_group.state == "groupNotFound":
             return None
-        not_started = league_group.number_of_rounds - len(league_group.rounds)
-        is_ending = league_group.state == "ended"
-        if not not_started and not is_ending:
+        last_round_active = league_group.number_of_rounds != len(league_group.rounds)
+        if not last_round_active and league_group.state != "":
             # there are the supposed number of rounds, but without any call we are unable to know if the last round is
             # currently in preparation or already in war
             kwargs["league_group"] = league_group
@@ -1146,20 +1145,20 @@ class Client:
             async for war in self.get_league_wars(league_group.rounds[-1], cls=cls, **kwargs):
                 if war.state == 'inWar':
                     # last round is already in war
-                    is_ending = True
+                    last_round_active = True
                     break
                 elif war.state == 'preparation':
                     # last round is still in preparation
-                    is_ending = False
+                    last_round_active = False
                     break
         if cwl_round is WarRound.current_war and league_group.state == "preparation":
             return None  # for round 1 and 15min prep between rounds this is a shortcut.
         elif cwl_round is WarRound.current_preparation and league_group.state == "ended":
             return None  # for the end of CWL there's no next prep day.
-        elif cwl_round is WarRound.current_war and is_ending:
-            round_tags = league_group.rounds[-1] # for the end of CWL current_war should give the last war
-        elif cwl_round is WarRound.previous_war and is_ending:
-            round_tags = league_group.rounds[-2] # for the end of CWL previous_war should give the second last war
+        elif cwl_round is WarRound.current_war and (last_round_active or league_group.state == "ended"):
+            round_tags = league_group.rounds[-1]  # for the end of CWL current_war should give the last war
+        elif cwl_round is WarRound.previous_war and (last_round_active or league_group.state == "ended"):
+            round_tags = league_group.rounds[-2]  # for the end of CWL previous_war should give the second last war
         elif cwl_round is WarRound.previous_war and len(league_group.rounds) < 3:
             return None  # no previous war for two rounds.
         elif cwl_round is WarRound.previous_war:

--- a/coc/client.py
+++ b/coc/client.py
@@ -1134,18 +1134,18 @@ class Client:
                 raise PrivateWarLog(exception.response, exception.reason) from exception
             return get_war
 
-        is_prep = league_group.state == "preparation"
-
-        if cwl_round is WarRound.current_war and league_group.state == "preparation":
+        if league_group.state == "notInWar" or league_group.state == "groupNotFound":
+            return None
+        elif cwl_round is WarRound.current_war and league_group.state == "preparation":
             return None  # for round 1 and 15min prep between rounds this is a shortcut.
         elif cwl_round is WarRound.current_preparation and league_group.state == "ended":
             return None  # for the end of CWL there's no next prep day.
-        elif cwl_round is WarRound.previous_war and len(league_group.rounds) == 1:
-            return None  # no previous war for first rounds.
         elif cwl_round is WarRound.current_war and league_group.state == "ended":
             round_tags = league_group.rounds[-1] # for the end of CWL current_war should give the last war
-        elif cwl_round is WarRound.previous_war and is_prep:
-            round_tags = league_group.rounds[-2]
+        elif cwl_round is WarRound.previous_war and league_group.state == "ended":
+            round_tags = league_group.rounds[-2] # for the end of CWL previous_war should give the second last war
+        elif cwl_round is WarRound.previous_war and len(league_group.rounds) < 3:
+            return None  # no previous war for two rounds.
         elif cwl_round is WarRound.previous_war:
             round_tags = league_group.rounds[-3]
         elif cwl_round is WarRound.current_war:

--- a/coc/client.py
+++ b/coc/client.py
@@ -1136,12 +1136,10 @@ class Client:
 
         if league_group.state == "notInWar" or league_group.state == "groupNotFound":
             return None
-        last_round_active = league_group.number_of_rounds != len(league_group.rounds)
-        if not last_round_active and league_group.state != "":
+        last_round_active = league_group.number_of_rounds == len(league_group.rounds)
+        if last_round_active and league_group.state != "ended":
             # there are the supposed number of rounds, but without any call we are unable to know if the last round is
             # currently in preparation or already in war
-            kwargs["league_group"] = league_group
-            kwargs["clan_tag"] = clan_tag
             async for war in self.get_league_wars(league_group.rounds[-1], cls=cls, **kwargs):
                 if war.state == 'inWar':
                     # last round is already in war


### PR DESCRIPTION
Noticed plenty of IndexErrors (see below) in my logs by basically every clan which is currently not in a normal war. You can test it for example with `#2PP0R0VJ0` or `#2L8CLUYYU` (Written 8:51 am UTC). Those clans havent started cwl yet, so leaguegroup has the state `notInWar`, which isn't handled properly. Causing this index error. 
```
Ignoring exception in event task.
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/coc/events.py", line 1067, in _run_war_update
    war = await meth(clan_tag, cls=self.war_cls, round=cwl_round)
  File "/usr/local/lib/python3.9/site-packages/coc/client.py", line 1084, in get_current_war
    round_tags = league_group.rounds[-2]
IndexError: list index out of range
```
The fix for that are the changes in line 1137-1138, it just escapes the states, where no rounds are in the response of the api.

Because I was already thinking about the code, I remembered that we have also other problems.

The previous war was often wrong. In the old code line 1143-1144 should deal with the cases where there is no finished cwl round. But the check only worked for the first round meaning we have one round in preparation. There is another case where first round is currently active and second round is in preparation where no previous round exist. The fix for that is new code line 1147-1148.

The second problem was the last round until the last round ended. Where current war is already the last round but due to the league_group.state being still not 'ended', it returned the second last round as current war. By adding the check, this issue should be solved with only one additional call (I still iterate over all wartags just in case there is something completely odd happening)