### PR TITLE
Fix bug where keys are not properly handled+ClanEvents.member_count

### DIFF
--- a/coc/__init__.py
+++ b/coc/__init__.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 from .abc import BasePlayer, BaseClan
 from .clans import RankedClan, Clan

--- a/coc/events.py
+++ b/coc/events.py
@@ -83,7 +83,7 @@ class _ValidateEvent:
             return self.cls.__getattr__(self.cls, item)
 
         # handle member_x events:
-        if "member_" in item:
+        if "member_" in item and item != "member_count":
             item = item.replace("member_", "")
             nested = True
         else:

--- a/coc/events.py
+++ b/coc/events.py
@@ -83,7 +83,7 @@ class _ValidateEvent:
             return self.cls.__getattr__(self.cls, item)
 
         # handle member_x events:
-        if "member_" in item and item != "member_count":
+        if "member_" in item:
             item = item.replace("member_", "")
             nested = True
         else:

--- a/coc/http.py
+++ b/coc/http.py
@@ -483,8 +483,13 @@ class HTTPClient:
 
             resp = await session.post("https://developer.clashofclans.com/api/apikey/list")
             keys = (await resp.json())["keys"]
-            self._keys.extend(key["key"] for c, key in enumerate(keys) if key["name"] == self.key_names and ip in key[
-                "cidrRanges"] and c <= self.key_count)
+            for key in keys:
+                LOG.debug(f"Key {key}")
+                if key["name"] != self.key_names or ip not in key["cidrRanges"]:
+                    continue
+                self._keys.append(key["key"])
+                if len(self._keys) == self.key_count:
+                    break
 
             LOG.info("Retrieved %s valid keys from the developer site.", len(self._keys))
 

--- a/docs/miscellaneous/changelog.rst
+++ b/docs/miscellaneous/changelog.rst
@@ -7,6 +7,15 @@ Changelog
 This page keeps a fairly detailed, human readable version
 of what has changed, and whats new for each version of the lib.
 
+
+v2.3.1
+------
+
+- Fixed a bug with the retrieval of api keys
+
+- Fixed :func:`ClanEvents.member_count`
+ 
+ 
 v2.4.0
 ------
 Additions:

--- a/docs/miscellaneous/changelog.rst
+++ b/docs/miscellaneous/changelog.rst
@@ -8,8 +8,11 @@ This page keeps a fairly detailed, human readable version
 of what has changed, and whats new for each version of the lib.
 
 
-v2.3.1
+v2.4.1
 ------
+
+Bugs Fixed:
+~~~~~~~~~~~
 
 - Fixed a bug with the retrieval of api keys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "coc.py"
 authors = [{ name = "mathsman5133" }]
 maintainers = [{ name = "majordoobie" }, { name = "MagicTheDev" }, { name = "Kuchenmampfer" }, { name = "lukasthaler" }, { name = "doluk" }]
-version = "2.4.0"
+version = "2.4.1"
 description = "A python wrapper for the Clash of Clans API"
 requires-python = ">=3.7.3"
 readme = "README.rst"


### PR DESCRIPTION
he internal handling of the existing keys was of. the keys got enumerated and then checked for ip and key name as they should, but we also compared the index from the enumerate with the key count. and only append if it is smaller equal than the key count. And in case you only use one key, but your already existing key exists not at the first two places then it would never find it