### PR TITLE
Cache fix

### DIFF
--- a/coc/errors.py
+++ b/coc/errors.py
@@ -53,8 +53,14 @@ class HTTPException(ClashOfClansException):
     __slots__ = ("response", "status", "message", "reason", "_data")
 
     def _from_response(self, response, data):
-        self.response = response
-        self.status = response.status
+        if isinstance(response, int):
+            self.status = response
+            self.response = None
+        elif isinstance(response, ClientResponse):
+            self.response = response
+            self.status = response.status
+        else:
+            self.response = self.status = None
 
         if isinstance(data, dict):
             self.reason = data.get("reason", "Unknown")
@@ -73,7 +79,7 @@ class HTTPException(ClashOfClansException):
         super().__init__(fmt.format(self))
 
     def __init__(self, response=None, data=None):
-        if isinstance(response, ClientResponse):
+        if isinstance(response, (ClientResponse, int)):
             self._from_response(response, data)
         else:
             self.response = None

--- a/coc/http.py
+++ b/coc/http.py
@@ -267,18 +267,15 @@ class HTTPClient:
                 data = cache[cache_control_key]
                 status_code = data.get("status_code")
                 if data.get("timestamp") and data.get("timestamp") + data.get("_response_retry", 0) < datetime.utcnow().timestamp():
-                    pass
+                    self._cache_remove(cache_control_key)
                 elif not status_code or 200 <= status_code < 300:
                     return data
                 elif status_code == 400:
                     raise InvalidArgument(400, data)
-
                 elif status_code == 403:
                     raise Forbidden(403, data)
-
                 elif status_code == 404:
                     raise NotFound(404, data)
-
                 elif status_code == 503:
                     raise Maintenance(503, data)
             except KeyError:


### PR DESCRIPTION
In the past, the data of the response got written without any further information into the cache. For example get_league_group then just writes {"reason": "notfound"} into the cache and raise 404 as it should on the first request. The second invoke of get_league_group for the same clan would then lead to an empty league group, because data from the cache is used and it doesn't contain anything of the actual data, resulting in an empy leaguegroup which would brake other things, like get_current_war for example. Because the rounds are an empty list all of the sudden and then accessing index -1 throws an  IndexError (which resulted in my case in a 6.4 GB big service error log file...).

The changes add the response.status to the data in the cache and invoke the same error again if the cached data is used. On top I added an explicit check if the data is already too old to be used. Just in case the removal fails. This will also help investigating any potential memory leak better (or a regular clean up).