### PR TITLE
fix missing attribute _cs_raid_attacks

### DIFF
--- a/coc/__init__.py
+++ b/coc/__init__.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 
 from .abc import BasePlayer, BaseClan
 from .clans import RankedClan, Clan

--- a/coc/raid.py
+++ b/coc/raid.py
@@ -287,6 +287,7 @@ class RaidClan:
         "_attacks",
         "_client",
         "_response_retry",
+        "_cs_raid_attacks",
         "_cs_raid_districts",
         "_cs_looted",
         "_iter_raid_districts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "coc.py"
 authors = [{ name = "mathsman5133" }]
 maintainers = [{ name = "majordoobie" }, { name = "MagicTheDev" }, { name = "Kuchenmampfer" }, { name = "lukasthaler" }, { name = "doluk" }]
-version = "2.4.1"
+version = "2.4.2"
 description = "A python wrapper for the Clash of Clans API"
 requires-python = ">=3.7.3"
 readme = "README.rst"


### PR DESCRIPTION
This should be included in 2.4.2, so we should port it to master