### PR TITLE
Fix PyPi workflow to use newer `build` tool, and add back in checking out repo.

### DIFF
--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -17,7 +17,7 @@ jobs:
       url: https://pypi.org/p/coc.py
     permissions:
       id-token: write
-    if: github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' &&  github.event.inputs.confirmation != '')
+    if: github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' &&  github.event.inputs.confirmation != 'false')
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -17,6 +17,7 @@ jobs:
       url: https://pypi.org/p/coc.py
     permissions:
       id-token: write
+    if: github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' &&  github.event.inputs.confirmation != '')
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -20,16 +20,17 @@ jobs:
     permissions:
       id-token: write
     steps:
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install --upgrade pip
+        pip install --upgrade build
     - name: Build
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -2,11 +2,9 @@ on:
   workflow_dispatch:
     inputs:
       confirmation:
-        description: 'I want to manually trigger a PyPi push, without publishing a GitHub release (recommended)'
+        description: 'I want to manually trigger a PyPi push, without publishing a GitHub release (not recommended!)'
         required: true
-        type: choice
-        options:
-          - Yes
+        type: boolean
   release:
     types: [created]
 


### PR DESCRIPTION
If someone knows how to make the check box a compulsory "true" for the workflow_dispatch that would be good, too, but I'm not too fussed