### PR TITLE
Fix: Remove comparison in league group

### DIFF
--- a/coc/__init__.py
+++ b/coc/__init__.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = "3.8.1"
+__version__ = "3.8.2"
 
 from .abc import BasePlayer, BaseClan
 from .clans import RankedClan, Clan

--- a/coc/wars.py
+++ b/coc/wars.py
@@ -440,7 +440,7 @@ class ClanWarLeagueGroup:
         # the API returns a list and the rounds that haven't started contain war tags of #0 (not sure why)...
         # we want to get only the valid rounds
         self.rounds: List[List[str]] = [n["warTags"] for n in rounds if
-                                        n["warTags"][0] != "#0" or n]
+                                        n["warTags"][0] != "#0"]
 
         self.__iter_clans = (ClanWarLeagueClan(data=data, client=self._client)
                              for data in data_get("clans", []))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.append((root_project / "docs").as_posix())
 project = 'coc'
 copyright = '2022, mathsman5133'
 author = 'mathsman5133'
-release = '3.8.1'
+release = '3.8.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/miscellaneous/changelog.rst
+++ b/docs/miscellaneous/changelog.rst
@@ -7,6 +7,13 @@ Changelog
 This page keeps a fairly detailed, human readable version
 of what has changed, and whats new for each version of the lib.
 
+v3.8.2
+------
+
+Bugs Fixed:
+~~~~~~~~~~~
+- Fixed a bug with :func:`coc.Client.get_current_war` that caused it to not fetch the correct current CWL war
+
 v3.8.1
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "coc.py"
 authors = [{ name = "mathsman5133" }]
 maintainers = [{ name = "majordoobie" }, { name = "MagicTheDev" }, { name = "Kuchenmampfer" },
     { name = "lukasthaler"}, { name = "doluk"}]
-version = "3.8.1"
+version = "3.8.2"
 description = "A python wrapper for the Clash of Clans API"
 requires-python = ">=3.7.3"
 readme = "README.rst"


### PR DESCRIPTION
Remove the `or n` comparison as it always returns true as long as "n" exists, which it does, just with "empty" war tags of "#0" (hopefully I'm not wrong about that, but I'm quite sure that's the case)