### PR TITLE
Fix/realtime kwargs

### DIFF
--- a/coc/__init__.py
+++ b/coc/__init__.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = "3.8.2"
+__version__ = "3.8.3"
 
 from .abc import BasePlayer, BaseClan
 from .clans import RankedClan, Clan

--- a/coc/client.py
+++ b/coc/client.py
@@ -280,6 +280,7 @@ class Client:
             "lookup_cache": self.lookup_cache,
             "update_cache": self.update_cache,
             "ignore_cached_errors": self.ignore_cached_errors,
+            "realtime": self.realtime,
         }
 
     async def __aenter__(self):
@@ -957,15 +958,7 @@ class Client:
             clan_tag = correct_tag(clan_tag)
 
         try:
-            realtime = kwargs.get("realtime")
-        except KeyError:
-            realtime = None
-
-        try:
-            data = await self.http.get_clan_current_war(clan_tag, realtime=realtime,
-                                                        lookup_cache=kwargs.get("lookup_cache", self.lookup_cache),
-                                                        update_cache=kwargs.get("update_cache", self.update_cache),
-                                                        ignore_cached_errors=kwargs.get("ignore_cached_errors", self.ignore_cached_errors))
+            data = await self.http.get_clan_current_war(clan_tag, **{**self._defaults, **kwargs})
         except Forbidden as exception:
             raise PrivateWarLog(exception.response, exception.reason) from exception
 
@@ -1082,12 +1075,7 @@ class Client:
             clan_tag = correct_tag(clan_tag)
 
         try:
-            realtime = kwargs.get("realtime")
-        except KeyError:
-            realtime = None
-
-        try:
-            data = await self.http.get_clan_war_league_group(clan_tag, realtime=realtime, **{**self._defaults, **kwargs})
+            data = await self.http.get_clan_war_league_group(clan_tag, **{**self._defaults, **kwargs})
         except Forbidden as exception:
             raise PrivateWarLog(exception.response, exception.reason) from exception
         except asyncio.TimeoutError:
@@ -1140,12 +1128,7 @@ class Client:
             war_tag = correct_tag(war_tag)
 
         try:
-            realtime = kwargs.get("realtime")
-        except KeyError:
-            realtime = None
-
-        try:
-            data = await self.http.get_cwl_wars(war_tag, realtime=realtime, **{**self._defaults, **kwargs})
+            data = await self.http.get_cwl_wars(war_tag, **{**self._defaults, **kwargs})
         except Forbidden as exception:
             raise PrivateWarLog(exception.response, exception.reason) from exception
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.append((root_project / "docs").as_posix())
 project = 'coc'
 copyright = '2022, mathsman5133'
 author = 'mathsman5133'
-release = '3.8.2'
+release = '3.8.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/miscellaneous/changelog.rst
+++ b/docs/miscellaneous/changelog.rst
@@ -7,6 +7,13 @@ Changelog
 This page keeps a fairly detailed, human readable version
 of what has changed, and whats new for each version of the lib.
 
+v3.8.3
+------
+
+Bugs Fixed:
+~~~~~~~~~~~
+- Fixed a bug in serveral war related endpoints that passed realtime twice to the http client.
+
 v3.8.2
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "coc.py"
 authors = [{ name = "mathsman5133" }]
 maintainers = [{ name = "majordoobie" }, { name = "MagicTheDev" }, { name = "Kuchenmampfer" },
     { name = "lukasthaler"}, { name = "doluk"}]
-version = "3.8.2"
+version = "3.8.3"
 description = "A python wrapper for the Clash of Clans API"
 requires-python = ">=3.7.3"
 readme = "README.rst"


### PR DESCRIPTION
This pull request includes several changes to update the version of the package and fix bugs related to war-related endpoints. The most important changes include updating the version number, fixing a bug where the `realtime` parameter was passed twice, and updating the documentation to reflect the new version.

Version update:

* [`coc/__init__.py`](diffhunk://#diff-485f6eda2496836ade7c8d9423752f6c79beac950e3026778015c223b6063c8dL25-R25): Updated the version from `3.8.2` to `3.8.3`.
* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L18-R18): Updated the release version from `3.8.2` to `3.8.3`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10): Updated the version from `3.8.2` to `3.8.3`.

Bug fixes:

* [`coc/client.py`](diffhunk://#diff-47bc6aaefc4d4771aa2737d0655b176c5cc89586726211b3bab90f9139dcededL960-R961): Fixed a bug in several war-related endpoints where the `realtime` parameter was passed twice to the HTTP client by using `self._defaults` in the method calls. [[1]](diffhunk://#diff-47bc6aaefc4d4771aa2737d0655b176c5cc89586726211b3bab90f9139dcededL960-R961) [[2]](diffhunk://#diff-47bc6aaefc4d4771aa2737d0655b176c5cc89586726211b3bab90f9139dcededL1085-R1078) [[3]](diffhunk://#diff-47bc6aaefc4d4771aa2737d0655b176c5cc89586726211b3bab90f9139dcededL1143-R1131)
* [`docs/miscellaneous/changelog.rst`](diffhunk://#diff-6d861358c153571e33606860640b6db410a98d731549381bcb4bd32075f09117R10-R16): Added an entry for version `3.8.3` detailing the bug fix for the `realtime` parameter issue.