### PR TITLE
Fix super hog army id key

### DIFF
--- a/coc/__init__.py
+++ b/coc/__init__.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = "3.8.3"
+__version__ = "3.8.4"
 
 from .abc import BasePlayer, BaseClan
 from .clans import RankedClan, Clan

--- a/coc/static/troop_ids.json
+++ b/coc/static/troop_ids.json
@@ -40,7 +40,7 @@
     "Super Minion": "84",
     "Electro Titan": "95",
     "Apprentice Warden": "97",
-    "Super Hog": "98",
+    "Super Hog Rider": "98",
     "Root Rider": "110",
     "Druid" : "123",
     "Thrower" : "132",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.append((root_project / "docs").as_posix())
 project = 'coc'
 copyright = '2022, mathsman5133'
 author = 'mathsman5133'
-release = '3.8.3'
+release = '3.8.4'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/miscellaneous/changelog.rst
+++ b/docs/miscellaneous/changelog.rst
@@ -7,12 +7,19 @@ Changelog
 This page keeps a fairly detailed, human readable version
 of what has changed, and whats new for each version of the lib.
 
+v3.8.4
+------
+
+Bugs Fixed:
+~~~~~~~~~~~
+- Fixed a bug in army ids where "Super Hog Rider" was defined as "Super Hog"
+
 v3.8.3
 ------
 
 Bugs Fixed:
 ~~~~~~~~~~~
-- Fixed a bug in serveral war related endpoints that passed realtime twice to the http client.
+- Fixed a bug in several war related endpoints that passed realtime twice to the http client.
 
 v3.8.2
 ------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "coc.py"
 authors = [{ name = "mathsman5133" }]
 maintainers = [{ name = "majordoobie" }, { name = "MagicTheDev" }, { name = "Kuchenmampfer" },
     { name = "lukasthaler"}, { name = "doluk"}]
-version = "3.8.3"
+version = "3.8.4"
 description = "A python wrapper for the Clash of Clans API"
 requires-python = ">=3.7.3"
 readme = "README.rst"


### PR DESCRIPTION
- army id key was defined as "Super Hog" instead of "Super Hog Rider"