### PR TITLE
Fix pyproject.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ docs = ["sphinx",
 ]
 
 [tool.setuptools]
-packages = ["coc", "coc.ext.discordlinks", "coc.static", "coc.ext.fullwarapi", "coc.ext.triggers"]
+packages = ["coc", "coc.ext.discordlinks", "coc.static", "coc.ext.triggers"]
 include-package-data = true
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Happened to run into as i had a project pulling from master. 
Updated pyproject.toml to match what was removed in https://github.com/mathsman5133/coc.py/pull/267