### PR TITLE
fix: TimeDelta calculations

### DIFF
--- a/coc/miscmodels.py
+++ b/coc/miscmodels.py
@@ -175,13 +175,18 @@ class TimeDelta:
 
     """
     def __init__(self, days=0, hours=0, minutes=0, seconds=0):
-        _days, _hours = divmod(hours, 24)
-        _hours_left, _mins = divmod(minutes, 60)
+        total_seconds = (
+            (days or 0) * 86400 +
+            (hours or 0) * 3600 +
+            (minutes or 0) * 60 +
+            (seconds or 0)
+        )
 
-        self.days = days + _days
-        self.hours = hours + _hours + _hours_left
-        self.minutes = minutes + _mins
-        self.seconds = seconds
+        self._total_seconds = total_seconds
+
+        self.days, rem = divmod(total_seconds, 86400)
+        self.hours, rem = divmod(rem, 3600)
+        self.minutes, self.seconds = divmod(rem, 60)
 
     def total_seconds(self):
         """Returns the total number of seconds in the time object.
@@ -192,10 +197,7 @@ class TimeDelta:
         -------
         int
             The number of seconds"""
-        return self.days * 24 * 60 * 60 + \
-               self.hours * 60 * 60 + \
-               self.minutes * 60 + \
-               self.seconds
+        return self._total_seconds
 
 
 class Location:


### PR DESCRIPTION
- PR refactors TimeDelta class constructor to simplify time normalization logic with single calculation for total_seconds.
- Added handling for None types to prevent TypeError for math operations

Previous TimeDelta class constructor:
```

    def __init__(self, days=0, hours=0, minutes=0, seconds=0):
        _days, _hours = divmod(hours, 24)
        _hours_left, _mins = divmod(minutes, 60)

        self.days = days + _days
        # hours was set to hours again instead of the remainder of divmid(hours, 24)
        self.hours = hours + _hours + _hours_left
        self.minutes = minutes + _mins
        self.seconds = seconds

```

