### PR TITLE
Removal of calls to datetime.datetime.utcnow() and Bug fix for non json responses by the coc api

### DIFF
--- a/coc/__init__.py
+++ b/coc/__init__.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-__version__ = "3.9.1"
+__version__ = "3.9.2"
 
 from .abc import BasePlayer, BaseClan
 from .clans import RankedClan, Clan

--- a/coc/events.py
+++ b/coc/events.py
@@ -26,7 +26,7 @@ import logging
 import traceback
 
 from collections.abc import Iterable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import coc.raid
 from .client import Client
@@ -842,7 +842,7 @@ class EventsClient(Client):
         try:
             while self.loop.is_running():
                 end_of_season = get_season_end()
-                now = datetime.utcnow()
+                now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
                 await asyncio.sleep((end_of_season - now).total_seconds())
                 self.dispatch("new_season_start")
         except asyncio.CancelledError:
@@ -856,7 +856,7 @@ class EventsClient(Client):
             while self.loop.is_running():
                 clan_games_start = get_clan_games_start()
                 clan_games_end = get_clan_games_end()
-                now = datetime.utcnow()
+                now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
                 if now < clan_games_start:
                     event = "clan_games_start"
                     mute_time = clan_games_start - now
@@ -882,7 +882,7 @@ class EventsClient(Client):
                 except Maintenance:
                     if maintenance_start is None:
                         self._in_maintenance_event.clear()
-                        maintenance_start = datetime.utcnow()
+                        maintenance_start = datetime.now(tz=timezone.utc).replace(tzinfo=None)
                         self.dispatch("maintenance_start")
 
                     await asyncio.sleep(15)

--- a/coc/ext/discordlinks/__init__.py
+++ b/coc/ext/discordlinks/__init__.py
@@ -7,7 +7,7 @@ import typing
 import json
 
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 
 import aiohttp
 
@@ -39,7 +39,7 @@ def extract_expiry_from_jwt_token(token):
     dict_payload = json.loads(bytes_payload)
     try:
         expiry = dict_payload["exp"]
-        return datetime.fromtimestamp(expiry)
+        return datetime.fromtimestamp(expiry, tz=timezone.utc)
     except KeyError:
         return None
 
@@ -132,7 +132,7 @@ class DiscordLinkClient:
                 return await self._request(method, url, **kwargs)
 
     async def _get_key(self):
-        if not self.key or (self.key.expires_at and (self.key.expires_at < datetime.utcnow())):
+        if not self.key or (self.key.expires_at and (self.key.expires_at < datetime.now(tz=timezone.utc))):
             await self._refresh_key()
 
         return self.key.token

--- a/coc/http.py
+++ b/coc/http.py
@@ -26,7 +26,7 @@ import logging
 import re
 
 from collections import deque
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import cycle
 from time import process_time, perf_counter
 from typing import Optional
@@ -300,7 +300,8 @@ class HTTPClient:
             try:
                 data = cache[cache_control_key]
                 status_code = data.get("status_code")
-                if data.get("timestamp") and data.get("timestamp") + data.get("_response_retry", 0) < datetime.utcnow().timestamp():
+                if data.get("timestamp") and data.get("timestamp") + data.get("_response_retry", 0) < datetime.now(
+                        tz=timezone.utc).timestamp():
                     self._cache_remove(cache_control_key)
                 elif not status_code or 200 <= status_code < 300:
                     return data
@@ -331,8 +332,9 @@ class HTTPClient:
 
                         LOG.debug("API HTTP Request: %s", str(log_info))
                         data = (await json_or_text(response)) or {}
-                        data["status_code"] = response.status
-                        data["timestamp"] = datetime.utcnow().timestamp()
+                        if isinstance(data, dict):
+                            data["status_code"] = response.status
+                            data["timestamp"] = datetime.now(tz=timezone.utc).timestamp()
                         try:
                             # set a callback to remove the item from cache once it's stale.
                             delta = int(response.headers["Cache-Control"].strip("max-age=").strip("public max-age="))

--- a/coc/miscmodels.py
+++ b/coc/miscmodels.py
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Type, TypeVar, Optional
 
 import coc
@@ -558,7 +558,7 @@ class Timestamp:
     @property
     def now(self) -> datetime:
         """:class:`datetime`: Returns the time of the timestamp as a datetime object in UTC."""
-        return datetime.utcnow()
+        return datetime.now(tz=timezone.utc).replace(tzinfo=None)
 
     @property
     def seconds_until(self) -> int:

--- a/coc/utils.py
+++ b/coc/utils.py
@@ -27,7 +27,7 @@ import calendar
 import re
 
 from collections import deque, UserDict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 from operator import attrgetter
 from typing import Any, Callable, Generic, Iterable, List, Optional, Type, TypeVar, Tuple, Union
@@ -305,7 +305,7 @@ def get_season_start(month: Optional[int] = None, year: Optional[int] = None) ->
         # they want a specific month/year combo
         return get_start_for_month_year(month, year)
 
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     start = get_start_for_month_year(now.month, now.year)
     if now > start:
         # we got the right one, season started this month
@@ -352,7 +352,7 @@ def get_season_end(month: Optional[int] = None, year: Optional[int] = None) -> d
             next_year = year
         return get_season_start(next_month, next_year)
 
-    now = datetime.utcnow()
+    now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     end = get_season_start(now.month, now.year)
     if end > now:
         return end
@@ -388,7 +388,7 @@ def get_clan_games_start(time: Optional[datetime] = None) -> datetime:
         The start of the next or running clan games.
     """
     if time is None:
-        time = datetime.utcnow()
+        time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     month = time.month
     year = time.year
     this_months_cg_end = datetime(year=time.year, month=time.month, day=28, hour=8, minute=0, second=0)
@@ -421,7 +421,7 @@ def get_clan_games_end(time: Optional[datetime] = None) -> datetime:
         The end of the next or running clan games.
     """
     if time is None:
-        time = datetime.utcnow()
+        time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     month = time.month
     year = time.year
     this_months_cg_end = datetime(year=time.year, month=time.month, day=28, hour=8, minute=0, second=0)
@@ -454,7 +454,7 @@ def get_raid_weekend_start(time: Optional[datetime] = None) -> datetime:
         The start of the raid weekend.
     """
     if time is None:
-        time = datetime.utcnow()
+        time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     time = get_raid_weekend_end(time)
     time = time - timedelta(days=3)
     return time
@@ -482,7 +482,7 @@ def get_raid_weekend_end(time: Optional[datetime] = None) -> datetime:
     """
     # Shift the time so that we can pretend the raid ends just after midnight
     if time is None:
-        time = datetime.utcnow()
+        time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     time = time - timedelta(hours=7, microseconds=1)
     time = time + timedelta(weeks=1, days=-time.weekday())  # Go to the next monday
     time = time.replace(hour=7, minute=0, second=0, microsecond=0)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.append((root_project / "docs").as_posix())
 project = 'coc'
 copyright = '2022, mathsman5133'
 author = 'mathsman5133'
-release = '3.9.1'
+release = '3.9.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/miscellaneous/changelog.rst
+++ b/docs/miscellaneous/changelog.rst
@@ -7,6 +7,18 @@ Changelog
 This page keeps a fairly detailed, human readable version
 of what has changed, and whats new for each version of the lib.
 
+v3.9.2
+------
+
+Changes:
+~~~~~~~~
+- Removal of calls to `datetime.datetime.utcnow()` in favor of `datetime.datetime.now()` to avoid issues with timezones and prevent DeprecationWarnings.
+
+Bugs Fixed:
+~~~~~~~~~~~
+- Fixed a bug occuring when the CoC API returns a text response instead of a json response.
+
+
 v3.9.1
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "coc.py"
 authors = [{ name = "mathsman5133" }]
 maintainers = [{ name = "majordoobie" }, { name = "MagicTheDev" }, { name = "Kuchenmampfer" },
     { name = "lukasthaler"}, { name = "doluk"}]
-version = "3.9.1"
+version = "3.9.2"
 description = "A python wrapper for the Clash of Clans API"
 requires-python = ">=3.9.0"
 readme = "README.rst"


### PR DESCRIPTION
This pull request includes updates to the `coc` library to address timezone handling and prevent potential `DeprecationWarnings` by replacing calls to `datetime.datetime.utcnow()` with `datetime.datetime.now()` using an explicit UTC timezone. Additionally, it includes a version bump to `3.9.2` and a bug fix for handling text responses from the CoC API.

### Timezone Handling Updates:
* Replaced all occurrences of `datetime.utcnow()` with `datetime.now(tz=timezone.utc).replace(tzinfo=None)` across multiple files to ensure proper timezone handling and avoid `DeprecationWarnings`. [[1]](diffhunk://#diff-21b4e72d623669f74e043bb894aded02d35a963a9dfe2bb89ecc27bb0f5b1ef0L845-R845) [[2]](diffhunk://#diff-21b4e72d623669f74e043bb894aded02d35a963a9dfe2bb89ecc27bb0f5b1ef0L859-R859) [[3]](diffhunk://#diff-21b4e72d623669f74e043bb894aded02d35a963a9dfe2bb89ecc27bb0f5b1ef0L885-R885) [[4]](diffhunk://#diff-7c50bc56322e3439539de905099024734c205b3b429c305d76e2d71195599001L42-R42) [[5]](diffhunk://#diff-66fde604a8132e151ae73a20dd8898378b2899d2f5f78dca462ee9c4b0699d5bL303-R304) [[6]](diffhunk://#diff-c292efc3a84edc83d858472c2eb45a6247064a83cafa4c84debf3f1beb319786L308-R308) [[7]](diffhunk://#diff-c292efc3a84edc83d858472c2eb45a6247064a83cafa4c84debf3f1beb319786L355-R355) [[8]](diffhunk://#diff-c292efc3a84edc83d858472c2eb45a6247064a83cafa4c84debf3f1beb319786L391-R391) [[9]](diffhunk://#diff-c292efc3a84edc83d858472c2eb45a6247064a83cafa4c84debf3f1beb319786L424-R424) [[10]](diffhunk://#diff-c292efc3a84edc83d858472c2eb45a6247064a83cafa4c84debf3f1beb319786L457-R457) [[11]](diffhunk://#diff-c292efc3a84edc83d858472c2eb45a6247064a83cafa4c84debf3f1beb319786L485-R485) [[12]](diffhunk://#diff-4050ad3112476976c91959592e2411e5022cdd2ec9fd3486334b10af3bfed25dL561-R561)

### Version Update:
* Updated the library version from `3.9.1` to `3.9.2` in `coc/__init__.py`, `docs/conf.py`, and `pyproject.toml`. [[1]](diffhunk://#diff-485f6eda2496836ade7c8d9423752f6c79beac950e3026778015c223b6063c8dL25-R25) [[2]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L18-R18) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10)

### Bug Fix:
* Fixed a bug in `async def request` in `coc/http.py` to handle cases where the CoC API returns a text response instead of JSON. Added a check to ensure `data` is a dictionary before setting `timestamp`.

### Documentation Updates:
* Added a changelog entry for version `3.9.2` in `docs/miscellaneous/changelog.rst`, highlighting the timezone handling updates and the bug fix for text responses.